### PR TITLE
Separate tests

### DIFF
--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -472,6 +472,9 @@ impl StreamInstance {
                     return Poll::Pending;
                 }
                 StreamRecvState::StartComplete => {}
+                StreamRecvState::Shutdown => {
+                    return Poll::Ready(Ok(None));
+                }
                 StreamRecvState::ShutdownComplete => {
                     if let Some(conn_error) = &exclusive.conn_error {
                         return Poll::Ready(Err(ReadError::ConnectionLost(conn_error.clone())));
@@ -489,7 +492,10 @@ impl StreamInstance {
                 ReadStatus::Readable(read) | ReadStatus::Blocked(Some(read)) => {
                     Poll::Ready(Ok(Some(read)))
                 }
-                ReadStatus::Finished(read) => Poll::Ready(Ok(read)),
+                ReadStatus::Finished(read) => {
+                    exclusive.recv_state = StreamRecvState::Shutdown;
+                    Poll::Ready(Ok(read))
+                }
                 ReadStatus::Blocked(None) => {
                     exclusive.read_waiters.push(cx.waker().clone());
                     Poll::Pending
@@ -847,6 +853,7 @@ enum StreamRecvState {
     Closed,
     Start,
     StartComplete,
+    Shutdown,
     ShutdownComplete,
 }
 

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -636,6 +636,7 @@ impl StreamInstance {
                         write_buf.into_raw() as *const _,
                     )
                     .unwrap();
+                exclusive.send_state = StreamSendState::Shutdown;
                 Poll::Ready(Ok(val))
             }
         }


### PR DESCRIPTION
This pull request separates large tests into small ones. This pull request also includes changes to the `msquic-async/src/stream.rs` file to handle stream shutdown states correctly. The most important changes involve adding a new `Shutdown` state to the `StreamRecvState` enum and updating the `StreamInstance` implementation to properly handle this new state.
