### PR TITLE
Refactor imports to use h3_msquic module

### DIFF
--- a/h3-msquic/examples/client.rs
+++ b/h3-msquic/examples/client.rs
@@ -1,6 +1,7 @@
 /// This file is based on the `client.rs` example from the `h3` crate.
 use futures::future;
-use msquic_async::msquic;
+use h3_msquic::msquic;
+use h3_msquic::msquic_async;
 use std::ptr;
 use tokio::io::AsyncWriteExt;
 use tracing::info;

--- a/h3-msquic/examples/server.rs
+++ b/h3-msquic/examples/server.rs
@@ -3,8 +3,9 @@ use std::{ffi::CString, io::Write, net::SocketAddr, path::PathBuf, ptr, sync::Ar
 
 use argh::FromArgs;
 use bytes::{Bytes, BytesMut};
+use h3_msquic::msquic;
+use h3_msquic::msquic_async;
 use http::{Request, StatusCode};
-use msquic_async::msquic;
 use tempfile::NamedTempFile;
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{error, info};

--- a/h3-msquic/src/lib.rs
+++ b/h3-msquic/src/lib.rs
@@ -10,7 +10,8 @@ use h3::{
     ext::Datagram,
     quic::{self, Error, StreamId, WriteBuf},
 };
-use msquic_async::msquic;
+pub use msquic_async::msquic;
+pub use msquic_async;
 use std::fmt::{self, Display};
 use std::pin::Pin;
 use std::sync::Arc;


### PR DESCRIPTION
This pull request includes changes to the `h3-msquic` crate to update the imports and improve modularity. The most important changes involve updating the import paths for `msquic` and `msquic_async`.