### PR TITLE
Sync with the latest MsQuic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,11 +496,10 @@ dependencies = [
  "bitfield",
  "c-types",
  "cmake",
+ "ctor",
  "libc",
- "rcgen",
  "serde",
  "socket2",
- "tempfile",
 ]
 
 [[package]]

--- a/h3-msquic/examples/client.rs
+++ b/h3-msquic/examples/client.rs
@@ -15,9 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let api =
-        msquic::Api::new().map_err(|status| anyhow::anyhow!("Api::new failed: 0x{:x}", status))?;
-    let registration = msquic::Registration::new(&api, ptr::null())
+    let registration = msquic::Registration::new(ptr::null())
         .map_err(|status| anyhow::anyhow!("Registration::new failed: 0x{:x}", status))?;
 
     let alpn = [msquic::Buffer::from("h3")];
@@ -36,8 +34,7 @@ async fn main() -> anyhow::Result<()> {
     cred_config.cred_flags |= msquic::CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
     configuration.load_credential(&cred_config).unwrap();
 
-    let conn =
-        msquic_async::Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
     conn.start(&configuration, "127.0.0.1", 8443).await?;
     let h3_conn = h3_msquic::Connection::new(conn);
     let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;

--- a/h3-msquic/examples/client.rs
+++ b/h3-msquic/examples/client.rs
@@ -1,6 +1,7 @@
 /// This file is based on the `client.rs` example from the `h3` crate.
 use futures::future;
-use msquic_async::msquic;
+use h3_msquic::msquic;
+use h3_msquic::msquic_async;
 use std::ptr;
 use tokio::io::AsyncWriteExt;
 use tracing::info;

--- a/h3-msquic/examples/server.rs
+++ b/h3-msquic/examples/server.rs
@@ -32,9 +32,7 @@ async fn main() -> anyhow::Result<()> {
     let cmd_opts: CmdOptions = argh::from_env();
     let root = Arc::new(cmd_opts.root);
 
-    let api =
-        msquic::Api::new().map_err(|status| anyhow::anyhow!("Api::new failed: 0x{:x}", status))?;
-    let registration = msquic::Registration::new(&api, ptr::null())
+    let registration = msquic::Registration::new(ptr::null())
         .map_err(|status| anyhow::anyhow!("Registration::new failed: 0x{:x}", status))?;
     let alpn = [msquic::Buffer::from("h3")];
 
@@ -84,12 +82,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = msquic_async::Listener::new(
-        msquic::Listener::new(&api),
-        &registration,
-        configuration,
-        &api,
-    );
+    let listener =
+        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration);
 
     let addr: SocketAddr = "127.0.0.1:8443".parse()?;
     listener.start(&[msquic::Buffer::from("h3")], Some(addr))?;

--- a/h3-msquic/examples/server.rs
+++ b/h3-msquic/examples/server.rs
@@ -3,8 +3,9 @@ use std::{ffi::CString, io::Write, net::SocketAddr, path::PathBuf, ptr, sync::Ar
 
 use argh::FromArgs;
 use bytes::{Bytes, BytesMut};
+use h3_msquic::msquic;
+use h3_msquic::msquic_async;
 use http::{Request, StatusCode};
-use msquic_async::msquic;
 use tempfile::NamedTempFile;
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::{error, info};

--- a/h3-msquic/src/lib.rs
+++ b/h3-msquic/src/lib.rs
@@ -10,8 +10,8 @@ use h3::{
     ext::Datagram,
     quic::{self, Error, StreamId, WriteBuf},
 };
-pub use msquic_async::msquic;
 pub use msquic_async;
+pub use msquic_async::msquic;
 use std::fmt::{self, Display};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/h3-msquic/src/lib.rs
+++ b/h3-msquic/src/lib.rs
@@ -10,7 +10,8 @@ use h3::{
     ext::Datagram,
     quic::{self, Error, StreamId, WriteBuf},
 };
-use msquic_async::msquic;
+pub use msquic_async::msquic;
+pub use msquic_async;
 use std::fmt::{self, Display};
 use std::pin::Pin;
 use std::sync::Arc;

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -25,7 +25,7 @@ default = ["tokio"]
 bytes = { workspace = true }
 futures-io = { workspace = true }
 libc = { workspace = true }
-msquic = { workspace = true }
+msquic = { workspace = true, features = ["preview-api"] }
 once_cell = { workspace = true }
 rangemap = { workspace = true }
 socket2 = { workspace = true }

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -12,9 +12,7 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let api =
-        msquic::Api::new().map_err(|status| anyhow::anyhow!("Api::new failed: 0x{:x}", status))?;
-    let registration = msquic::Registration::new(&api, ptr::null())
+    let registration = msquic::Registration::new(ptr::null())
         .map_err(|status| anyhow::anyhow!("Registration::new failed: 0x{:x}", status))?;
 
     let alpn = [msquic::Buffer::from("sample")];
@@ -35,8 +33,7 @@ async fn main() -> anyhow::Result<()> {
     cred_config.cred_flags |= msquic::CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
     configuration.load_credential(&cred_config).unwrap();
 
-    let conn =
-        msquic_async::Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 
     let mut stream = conn

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -21,9 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     let _cmd_opts: CmdOptions = argh::from_env();
 
-    let api =
-        msquic::Api::new().map_err(|status| anyhow::anyhow!("Api::new failed: 0x{:x}", status))?;
-    let registration = msquic::Registration::new(&api, ptr::null())
+    let registration = msquic::Registration::new(ptr::null())
         .map_err(|status| anyhow::anyhow!("Registration::new failed: 0x{:x}", status))?;
 
     let alpn = [msquic::Buffer::from("sample")];
@@ -74,12 +72,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = msquic_async::Listener::new(
-        msquic::Listener::new(&api),
-        &registration,
-        configuration,
-        &api,
-    );
+    let listener =
+        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration);
 
     let addr: SocketAddr = "127.0.0.1:4567".parse()?;
     listener.start(&alpn, Some(addr))?;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -28,11 +28,9 @@ async fn test_connection_start() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
@@ -56,8 +54,8 @@ async fn test_connection_start() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
-    let conn1 = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn1 = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         let res = conn
             .start(
@@ -106,11 +104,9 @@ async fn test_connection_start() {
 async fn test_connection_poll_shutdown() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
@@ -142,7 +138,7 @@ async fn test_connection_poll_shutdown() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -173,11 +169,9 @@ async fn test_connection_poll_shutdown() {
 /// Test for ['Listener::accept()']
 #[test(tokio::test)]
 async fn test_listener_accept() {
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
@@ -207,7 +201,7 @@ async fn test_listener_accept() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         let _ = conn
             .start(
@@ -236,12 +230,10 @@ async fn test_listener_accept() {
 async fn test_open_outbound_stream() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_bidi_stream_count(1)
@@ -275,7 +267,7 @@ async fn test_open_outbound_stream() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -330,12 +322,10 @@ async fn test_open_outbound_stream() {
 async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_bidi_stream_count(1)
@@ -371,7 +361,7 @@ async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -453,12 +443,10 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_bidi_stream_count(1)
@@ -493,7 +481,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -595,12 +583,10 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
 async fn test_poll_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -629,7 +615,7 @@ async fn test_poll_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -671,12 +657,10 @@ async fn test_poll_write() {
 async fn test_write_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -705,7 +689,7 @@ async fn test_write_chunk() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -746,12 +730,10 @@ async fn test_write_chunk() {
 async fn test_write_chunks() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -780,7 +762,7 @@ async fn test_write_chunks() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -821,12 +803,10 @@ async fn test_write_chunks() {
 async fn test_poll_finish_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -855,7 +835,7 @@ async fn test_poll_finish_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -895,12 +875,10 @@ async fn test_poll_finish_write() {
 async fn test_poll_abort_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -930,7 +908,7 @@ async fn test_poll_abort_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -970,12 +948,10 @@ async fn test_poll_abort_write() {
 async fn test_poll_read() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -1007,7 +983,7 @@ async fn test_poll_read() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1047,12 +1023,10 @@ async fn test_poll_read() {
 async fn test_read_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -1107,7 +1081,7 @@ async fn test_read_chunk() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1153,12 +1127,10 @@ async fn test_read_chunk() {
 async fn test_read_chunk_multi_recv() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1)
@@ -1212,7 +1184,7 @@ async fn test_read_chunk_multi_recv() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1259,12 +1231,10 @@ async fn test_poll_abort_read() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_peer_unidi_stream_count(1),
@@ -1296,7 +1266,7 @@ async fn test_poll_abort_read() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1394,12 +1364,10 @@ async fn datagram_validation() {
     //let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let api = msquic::Api::new().unwrap();
-    let registration = msquic::Registration::new(&api, ptr::null()).unwrap();
+    let registration = msquic::Registration::new(ptr::null()).unwrap();
 
     let listener = new_server(
         &registration,
-        &api,
         msquic::Settings::new()
             .set_idle_timeout_ms(10000)
             .set_datagram_receive_enabled(true),
@@ -1430,7 +1398,7 @@ async fn datagram_validation() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(&registration), &registration, &api);
+    let conn = Connection::new(msquic::Connection::new(), &registration);
     set.spawn(async move {
         let res = conn
             .start(
@@ -1463,7 +1431,6 @@ async fn datagram_validation() {
 
 fn new_server(
     registration: &msquic::Registration,
-    api: &msquic::Api,
     settings: &msquic::Settings,
 ) -> Result<Listener> {
     let alpn = [msquic::Buffer::from("test")];
@@ -1502,7 +1469,7 @@ fn new_server(
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = Listener::new(msquic::Listener::new(api), registration, configuration, api);
+    let listener = Listener::new(msquic::Listener::new(), registration, configuration);
     Ok(listener)
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `h3-msquic` and `msquic-async` crates, focusing on simplifying the API usage and updating dependencies. The most important changes include removing the `Api` parameter from various constructors and functions, updating the `msquic` submodule, and modifying the `Cargo.toml` to include a new feature.