### PR TITLE
Improve error handling in examples

### DIFF
--- a/h3-msquic/examples/client.rs
+++ b/h3-msquic/examples/client.rs
@@ -29,10 +29,14 @@ async fn main() -> anyhow::Result<()> {
             .set_datagram_receive_enabled(true)
             .set_stream_multi_receive_enabled(true),
     )
-    .unwrap();
+    .map_err(|status| anyhow::anyhow!("Configuration::new failed: 0x{:x}", status))?;
     let mut cred_config = msquic::CredentialConfig::new_client();
     cred_config.cred_flags |= msquic::CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
-    configuration.load_credential(&cred_config).unwrap();
+    configuration
+        .load_credential(&cred_config)
+        .map_err(|status| {
+            anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
+        })?;
 
     let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
     conn.start(&configuration, "127.0.0.1", 8443).await?;

--- a/h3-msquic/examples/server.rs
+++ b/h3-msquic/examples/server.rs
@@ -47,22 +47,18 @@ async fn main() -> anyhow::Result<()> {
             .set_datagram_receive_enabled(true)
             .set_stream_multi_receive_enabled(true),
     )
-    .unwrap();
+    .map_err(|status| anyhow::anyhow!("Configuration::new failed: 0x{:x}", status))?;
 
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let mut cert_file = NamedTempFile::new().unwrap();
-    cert_file
-        .write_all(cert.serialize_pem().unwrap().as_bytes())
-        .unwrap();
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+    let mut cert_file = NamedTempFile::new()?;
+    cert_file.write_all(cert.serialize_pem()?.as_bytes())?;
     let cert_path = cert_file.into_temp_path();
-    let cert_path = CString::new(cert_path.to_str().unwrap().as_bytes()).unwrap();
+    let cert_path = CString::new(cert_path.to_path_buf().as_os_str().as_encoded_bytes())?;
 
-    let mut key_file = NamedTempFile::new().unwrap();
-    key_file
-        .write_all(cert.serialize_private_key_pem().as_bytes())
-        .unwrap();
+    let mut key_file = NamedTempFile::new()?;
+    key_file.write_all(cert.serialize_private_key_pem().as_bytes())?;
     let key_path = key_file.into_temp_path();
-    let key_path = CString::new(key_path.to_str().unwrap().as_bytes()).unwrap();
+    let key_path = CString::new(key_path.to_path_buf().as_os_str().as_encoded_bytes())?;
 
     let certificate_file = msquic::CertificateFile {
         private_key_file: key_path.as_ptr(),
@@ -81,7 +77,11 @@ async fn main() -> anyhow::Result<()> {
         allowed_cipher_suites: 0,
     };
 
-    configuration.load_credential(&cred_config).unwrap();
+    configuration
+        .load_credential(&cred_config)
+        .map_err(|status| {
+            anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
+        })?;
     let listener =
         msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration);
 
@@ -156,7 +156,7 @@ where
         }
     };
 
-    let resp = http::Response::builder().status(status).body(()).unwrap();
+    let resp = http::Response::builder().status(status).body(())?;
 
     match stream.send_response(resp).await {
         Ok(_) => {

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -31,7 +31,11 @@ async fn main() -> anyhow::Result<()> {
 
     let mut cred_config = msquic::CredentialConfig::new_client();
     cred_config.cred_flags |= msquic::CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
-    configuration.load_credential(&cred_config).unwrap();
+    configuration
+        .load_credential(&cred_config)
+        .map_err(|status| {
+            anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
+        })?;
 
     let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
     conn.start(&configuration, "127.0.0.1", 4567).await?;


### PR DESCRIPTION
This pull request focuses on improving error handling in the `h3-msquic` and `msquic-async` examples by replacing `unwrap` calls with more descriptive error messages using `anyhow`. The changes ensure that errors are properly propagated and logged, improving the robustness and debuggability of the code.