### PR TITLE
Update msquic dependency to version 2.5.0-beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,8 @@ dependencies = [
 [[package]]
 name = "msquic"
 version = "2.5.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40ab1054745fa702e72960312816e329cba8ba2b8bfa30bfebdb0bce9fc7e83"
 dependencies = [
  "bitfield",
  "c-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-io = "0.3.30"
 h3 = { git = "https://github.com/hyperium/h3.git" }
 http = "1"
 libc = "0.2.153"
-msquic = { path = "./msquic" }
+msquic = "2.5.0-beta"
 msquic-async = { path = "./msquic-async" }
 once_cell = "1.19.0"
 rangemap = "1.5.1"


### PR DESCRIPTION
This pull request includes an update to the `Cargo.toml` file to change the `msquic` dependency from a local path to a specific version. 

Dependency update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R17): Changed the `msquic` dependency from a local path to version `2.5.0-beta`.