### PR TITLE
Update README with dependency instructions for Windows, Linux, and MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ MsQuic based quic library that supports async operation.
 
 ## Getting Started
 
+### Windows
 Add msquic-async in dependencies of your Cargo.toml.
 ```toml
-msquic-async = { git = "https://github.com/masa-koz/msquic-async-rs.git" }
+msquic-async = { version = "0.1.0", features = ["tls-schannel"] }
+```
+
+### Linux, MacOS
+Add msquic-async in dependencies of your Cargo.toml.
+```toml
+msquic-async = { version = "0.1.0" }
 ```
 
 The [examples](./msquic-async/examples) directory can help get started.


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to provide clearer instructions for adding `msquic-async` dependencies for different operating systems.

Dependency instructions update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R18): Added separate instructions for adding `msquic-async` dependencies in `Cargo.toml` for Windows, Linux, and MacOS.