### PR TITLE
Add symlink to main README in msquic-async directory

### DIFF
--- a/msquic-async/README.md
+++ b/msquic-async/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
This pull request includes a small change to the `msquic-async/README.md` file. The change adds a reference to the parent directory's `README.md` file.