### PR TITLE
Handle error of MsQuic API

### DIFF
--- a/h3-msquic/examples/h3-client.rs
+++ b/h3-msquic/examples/h3-client.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
             anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
         })?;
 
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
+    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
     conn.start(&configuration, "127.0.0.1", 8443).await?;
     let h3_conn = h3_msquic::Connection::new(conn);
     let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;

--- a/h3-msquic/examples/h3-server.rs
+++ b/h3-msquic/examples/h3-server.rs
@@ -147,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let listener =
-        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration);
+        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration)?;
 
     let addr: SocketAddr = "127.0.0.1:8443".parse()?;
     listener.start(&[msquic::Buffer::from("h3")], Some(addr))?;

--- a/h3-msquic/src/lib.rs
+++ b/h3-msquic/src/lib.rs
@@ -205,6 +205,8 @@ pub enum SendDatagramError {
     TooLarge,
     /// Network error
     ConnectionLost(Box<dyn Error>),
+    /// Other error
+    OtherError(u32),
 }
 
 impl fmt::Display for SendDatagramError {
@@ -215,6 +217,7 @@ impl fmt::Display for SendDatagramError {
             SendDatagramError::Disabled => write!(f, "datagram support disabled"),
             SendDatagramError::TooLarge => write!(f, "datagram too large"),
             SendDatagramError::ConnectionLost(_) => write!(f, "connection lost"),
+            SendDatagramError::OtherError(code) => write!(f, "other error: Status 0x{:x}", code),
         }
     }
 }
@@ -243,6 +246,7 @@ impl From<msquic_async::DgramSendError> for SendDatagramError {
             msquic_async::DgramSendError::ConnectionLost(err) => {
                 Self::ConnectionLost(ConnectionError::from(err).into())
             }
+            msquic_async::DgramSendError::OtherError(status) => Self::OtherError(status),
         }
     }
 }

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
             anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
         })?;
 
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
+    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 
     let mut stream = conn

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -137,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let listener =
-        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration);
+        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration)?;
 
     let addr: SocketAddr = "127.0.0.1:4567".parse()?;
     listener.start(&alpn, Some(addr))?;

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -33,7 +33,7 @@ impl Connection {
                 ConnectionInner::native_callback,
                 Arc::into_raw(inner.clone()) as *const c_void,
             )
-            .map_err(|status| ConnectionError::OtherError(status))?;
+            .map_err(ConnectionError::OtherError)?;
         trace!("Connection({:p}) Open by local", &*inner);
         Ok(Self(Arc::new(ConnectionInstance(inner))))
     }
@@ -82,7 +82,7 @@ impl Connection {
                     .shared
                     .msquic_conn
                     .start(configuration, host, port)
-                    .map_err(|status| StartError::OtherError(status))?;
+                    .map_err(StartError::OtherError)?;
                 exclusive.state = ConnectionState::Connecting;
             }
             ConnectionState::Connecting => {}
@@ -101,10 +101,7 @@ impl Connection {
         &self,
         configuration: &msquic::Configuration,
     ) -> Result<(), u32> {
-        self.0
-            .shared
-            .msquic_conn
-            .set_configuration(configuration)
+        self.0.shared.msquic_conn.set_configuration(configuration)
     }
 
     /// Open a new outbound stream.
@@ -257,7 +254,7 @@ impl Connection {
                 msquic::SEND_FLAG_NONE,
                 write_buf.into_raw() as *const _,
             )
-            .map_err(|status| DgramSendError::OtherError(status));
+            .map_err(DgramSendError::OtherError);
         Poll::Ready(res)
     }
 
@@ -291,7 +288,7 @@ impl Connection {
                 msquic::SEND_FLAG_NONE,
                 write_buf.into_raw() as *const _,
             )
-            .map_err(|status| DgramSendError::OtherError(status))?;
+            .map_err(DgramSendError::OtherError)?;
         Ok(())
     }
 

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -30,7 +30,7 @@ impl Listener {
                     ListenerInner::native_callback,
                     &*inner as *const _ as *const c_void,
                 )
-                .map_err(|status| ListenError::OtherError(status))?;
+                .map_err(ListenError::OtherError)?;
         }
         Ok(Self(inner))
     }
@@ -53,7 +53,7 @@ impl Listener {
             .shared
             .msquic_listener
             .start(alpn.as_ref(), local_address.as_ref())
-            .map_err(|status| ListenError::OtherError(status))?;
+            .map_err(ListenError::OtherError)?;
         exclusive.state = ListenerState::StartComplete;
         Ok(())
     }

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -19,7 +19,7 @@ impl Listener {
         msquic_listener: msquic::Listener,
         registration: &msquic::Registration,
         configuration: msquic::Configuration,
-    ) -> Self {
+    ) -> Result<Self, ListenError> {
         let inner = Box::new(ListenerInner::new(msquic_listener, configuration));
         {
             inner
@@ -30,9 +30,9 @@ impl Listener {
                     ListenerInner::native_callback,
                     &*inner as *const _ as *const c_void,
                 )
-                .unwrap();
+                .map_err(|status| ListenError::OtherError(status))?;
         }
-        Self(inner)
+        Ok(Self(inner))
     }
 
     /// Start the listener.
@@ -53,7 +53,7 @@ impl Listener {
             .shared
             .msquic_listener
             .start(alpn.as_ref(), local_address.as_ref())
-            .unwrap();
+            .map_err(|status| ListenError::OtherError(status))?;
         exclusive.state = ListenerState::StartComplete;
         Ok(())
     }
@@ -179,7 +179,9 @@ impl ListenerInner {
         trace!("Listener({:p}) new connection event", inner);
 
         let new_conn = Connection::from_handle(payload.connection);
-        new_conn.set_configuration(&inner.shared.configuration);
+        if let Err(status) = new_conn.set_configuration(&inner.shared.configuration) {
+            return status;
+        }
 
         let mut exclusive = inner.exclusive.lock().unwrap();
         exclusive.new_connections.push_back(new_conn);
@@ -264,4 +266,6 @@ pub enum ListenError {
     Finished,
     #[error("failed")]
     Failed,
+    #[error("other error: status 0x{0:x}")]
+    OtherError(u32),
 }

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -52,7 +52,7 @@ impl Stream {
                 StreamInner::native_callback,
                 Arc::into_raw(inner.clone()) as *const c_void,
             )
-            .map_err(|status| StartError::OtherError(status))?;
+            .map_err(StartError::OtherError)?;
         trace!("Stream({:p}) Open by local", &*inner);
 
         Ok(Self(Arc::new(StreamInstance(inner))))
@@ -105,7 +105,7 @@ impl Stream {
                                 msquic::STREAM_START_FLAG_NONE
                             },
                     )
-                    .map_err(|status| StartError::OtherError(status))?;
+                    .map_err(StartError::OtherError)?;
                 exclusive.state = StreamState::Start;
                 if self.0.shared.stream_type == StreamType::Bidirectional {
                     exclusive.recv_state = StreamRecvState::Start;
@@ -617,7 +617,7 @@ impl StreamInstance {
                         msquic::SEND_FLAG_NONE,
                         write_buf.into_raw() as *const _,
                     )
-                    .map_err(|status| WriteError::OtherError(status))
+                    .map_err(WriteError::OtherError)
                 {
                     Ok(()) => Poll::Ready(Ok(Some(val))),
                     Err(e) => Poll::Ready(Err(e)),
@@ -635,7 +635,7 @@ impl StreamInstance {
                         msquic::SEND_FLAG_FIN,
                         write_buf.into_raw() as *const _,
                     )
-                    .map_err(|status| WriteError::OtherError(status))
+                    .map_err(WriteError::OtherError)
                 {
                     Ok(()) => {
                         exclusive.send_state = StreamSendState::Shutdown;
@@ -660,7 +660,7 @@ impl StreamInstance {
                     .shared
                     .msquic_stream
                     .shutdown(msquic::STREAM_SHUTDOWN_FLAG_GRACEFUL, 0)
-                    .map_err(|status| WriteError::OtherError(status))
+                    .map_err(WriteError::OtherError)
                 {
                     Ok(()) => {
                         exclusive.send_state = StreamSendState::Shutdown;
@@ -703,7 +703,7 @@ impl StreamInstance {
                     .shared
                     .msquic_stream
                     .shutdown(msquic::STREAM_SHUTDOWN_FLAG_ABORT_SEND, error_code)
-                    .map_err(|status| WriteError::OtherError(status))
+                    .map_err(WriteError::OtherError)
                 {
                     Ok(()) => {
                         exclusive.send_state = StreamSendState::Shutdown;
@@ -737,7 +737,7 @@ impl StreamInstance {
                     .shared
                     .msquic_stream
                     .shutdown(msquic::STREAM_SHUTDOWN_FLAG_ABORT_SEND, error_code)
-                    .map_err(|status| WriteError::OtherError(status))?;
+                    .map_err(WriteError::OtherError)?;
                 exclusive.send_state = StreamSendState::Shutdown;
                 Ok(())
             }
@@ -762,7 +762,7 @@ impl StreamInstance {
                     .shared
                     .msquic_stream
                     .shutdown(msquic::STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, error_code)
-                    .map_err(|status| ReadError::OtherError(status))
+                    .map_err(ReadError::OtherError)
                 {
                     Ok(()) => {
                         exclusive.recv_state = StreamRecvState::ShutdownComplete;
@@ -796,7 +796,7 @@ impl StreamInstance {
                     .shared
                     .msquic_stream
                     .shutdown(msquic::STREAM_SHUTDOWN_FLAG_ABORT_RECEIVE, error_code)
-                    .map_err(|status| ReadError::OtherError(status))?;
+                    .map_err(ReadError::OtherError)?;
                 exclusive.recv_state = StreamRecvState::ShutdownComplete;
             }
             _ => {

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -50,8 +50,8 @@ async fn test_connection_start() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
-    let conn1 = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn1 = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         let res = conn
             .start(
@@ -135,7 +135,7 @@ async fn test_connection_poll_shutdown() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -199,7 +199,7 @@ async fn test_listener_accept() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         let _ = conn
             .start(
@@ -265,7 +265,7 @@ async fn test_open_outbound_stream() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -359,7 +359,7 @@ async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -479,7 +479,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -613,7 +613,7 @@ async fn test_poll_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -687,7 +687,7 @@ async fn test_write_chunk() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -760,7 +760,7 @@ async fn test_write_chunks() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -833,7 +833,7 @@ async fn test_poll_finish_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -906,7 +906,7 @@ async fn test_poll_abort_write() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -981,7 +981,7 @@ async fn test_poll_read() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1079,7 +1079,7 @@ async fn test_read_chunk() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1182,7 +1182,7 @@ async fn test_read_chunk_multi_recv() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1264,7 +1264,7 @@ async fn test_poll_abort_read() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1396,7 +1396,7 @@ async fn datagram_validation() {
         msquic::Settings::new().set_idle_timeout_ms(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration);
+    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
     set.spawn(async move {
         let res = conn
             .start(
@@ -1470,7 +1470,7 @@ fn new_server(
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = Listener::new(msquic::Listener::new(), registration, configuration);
+    let listener = Listener::new(msquic::Listener::new(), registration, configuration)?;
     Ok(listener)
 }
 
@@ -1536,7 +1536,7 @@ fn new_server(
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = Listener::new(msquic::Listener::new(), registration, configuration);
+    let listener = Listener::new(msquic::Listener::new(), registration, configuration)?;
     Ok(listener)
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling and ensure proper error propagation throughout the `msquic-async` and `h3-msquic` libraries. The most important changes include adding error handling to connection and listener creation, updating error enumerations, and modifying methods to return `Result` types.

### Error Handling Improvements:

* `h3-msquic/examples/h3-client.rs`, `h3-msquic/examples/h3-server.rs`, `msquic-async/examples/client.rs`, `msquic-async/examples/server.rs`: Added error handling to the creation of `msquic_async::Connection` and `msquic_async::Listener` by using the `?` operator. [[1]](diffhunk://#diff-aa863b51ebfbfd99cb8ac70c27291e846f24ecc98f6dcac3b29e0c5885960385L41-R41) [[2]](diffhunk://#diff-45719e6e2adb5f2344503651554d23fcb808bd0f09529bff44926d627f7a9a44L150-R150) [[3]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4L40-R40) [[4]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL140-R140)

* [`msquic-async/src/connection.rs`](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L23-R26): Modified the `Connection::new`, `Connection::start`, `Connection::set_configuration`, and datagram send methods to return `Result` types and propagate errors using `map_err`. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L23-R26) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L33-R38) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L82-R85) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L97-L102) [[5]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L245-R251) [[6]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L254-R261) [[7]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L288-R294)

* [`msquic-async/src/listener.rs`](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L22-R22): Updated `Listener::new`, `Listener::start`, and `ListenerInner::new_connection` to return `Result` types and handle errors appropriately. [[1]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L22-R22) [[2]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L33-R35) [[3]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L56-R56) [[4]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L182-R184)

### Error Enumeration Updates:

* `h3-msquic/src/lib.rs`, `msquic-async/src/connection.rs`, `msquic-async/src/listener.rs`, `msquic-async/src/stream.rs`: Added new variants to error enums such as `SendDatagramError`, `ConnectionError`, `DgramReceiveError`, `DgramSendError`, `StartError`, `ShutdownError`, `ListenError`, and `WriteError` to handle other errors with specific status codes. [[1]](diffhunk://#diff-1350f63f48d892d9dd5f9407c2644ca969ce640e354701f657706ae366d057e5R208-R209) [[2]](diffhunk://#diff-1350f63f48d892d9dd5f9407c2644ca969ce640e354701f657706ae366d057e5R220) [[3]](diffhunk://#diff-1350f63f48d892d9dd5f9407c2644ca969ce640e354701f657706ae366d057e5R249) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R719-R720) [[5]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R730-R731) [[6]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R745-R755) [[7]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R765-R766) [[8]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R269-R270) [[9]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L29-R32) [[10]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L52-R58) [[11]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L105-R108) [[12]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L125-R128) [[13]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L607-R611) [[14]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L616-R629) [[15]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L630-R646) [[16]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L645-R670)

### Stream Handling:

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L29-R32): Modified `Stream::open` and `StreamInstance` methods to return `Result` types and handle errors using `map_err`. This ensures that errors are properly propagated and handled during stream operations. [[1]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L29-R32) [[2]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L52-R58) [[3]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L105-R108) [[4]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L125-R128) [[5]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L607-R611) [[6]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L616-R629) [[7]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L630-R646) [[8]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L645-R670)…s for better error handling