### PR TITLE
prepare to publish msquic-async 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "msquic-async"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argh",

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # msquic-async
-MsQuic based quic library that supports async operation.
+[MsQuic](https://github.com/microsoft/msquic) based quic library that supports async operation.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/masa-koz/msquic-async-rs/actions/workflows/CI.yaml/badge.svg?branch=main)](https://github.com/masa-koz/msquic-async-rs/actions/workflows/CI.yaml)
 
 ## Getting Started
 
+Note that MsQuic, which is used to implement QUIC, needs to be built and linked. This is done automatically when building h3-msquic-async, but requires the cmake command to be available
+during the build process.
+
 ### Windows
 Add msquic-async in dependencies of your Cargo.toml.
 ```toml
-msquic-async = { version = "0.1.0", features = ["tls-schannel"] }
+msquic-async = { version = "0.2.0", features = ["tls-schannel"] }
 ```
 
 ### Linux, MacOS
 Add msquic-async in dependencies of your Cargo.toml.
 ```toml
-msquic-async = { version = "0.1.0" }
+msquic-async = { version = "0.2.0" }
 ```
 
-The [examples](./msquic-async/examples) directory can help get started.
+The [examples](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-async/examples) directory can help get started.
 
 ### Server
 
@@ -100,7 +103,7 @@ The [examples](./msquic-async/examples) directory can help get started.
     }
 ```
 
-You can find a full server example in [`msquic-async/examples/server.rs`](./msquic-async/examples/server.rs)
+You can find a full server example in [`msquic-async/examples/server.rs`](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-async/examples/server.rs)
 
 ### Client
 
@@ -130,7 +133,7 @@ You can find a full server example in [`msquic-async/examples/server.rs`](./msqu
             anyhow::anyhow!("Configuration::load_credential failed: 0x{:x}", status)
         })?;
 
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration);
+    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 
     let mut stream = conn
@@ -142,8 +145,8 @@ You can find a full server example in [`msquic-async/examples/server.rs`](./msqu
     info!("received: {}", String::from_utf8_lossy(&buf[0..len]));
 ```
 
-You can find a full client example in [`msquic-async/examples/client.rs`](./msquic-async/examples/client.rs)
+You can find a full client example in [`msquic-async/examples/client.rs`](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-async/examples/client.rs)
 
 ## License
 
-msquic-async is provided under the MIT license. See [LICENSE](LICENSE).
+msquic-async is provided under the MIT license. See [LICENSE](https://github.com/masa-koz/msquic-async-rs/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 ## Getting Started
 
-Note that MsQuic, which is used to implement QUIC, needs to be built and linked. This is done automatically when building h3-msquic-async, but requires the cmake command to be available
-during the build process.
+Note that MsQuic, which is used to implement QUIC, needs to be built and linked. This is done automatically when building h3-msquic-async, but requires the cmake command to be available during the build process.
 
 ### Windows
 Add msquic-async in dependencies of your Cargo.toml.

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "msquic-async"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
-description = "msquic based quic library that supports async operation"
+description = "MsQuic based quic library that supports async operation"
 repository = "https://github.com/masa-koz/msquic-async-rs"
 readme = "README.md"
 keywords = ["quic", "async"]


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `msquic-async/Cargo.toml` files to improve documentation and update the project version.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R23): Added a link to the MsQuic GitHub repository and updated the instructions to note the requirement of the `cmake` command during the build process.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R105): Updated the examples directory link to point to the correct GitHub repository path.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R135): Updated the server example link to point to the correct GitHub repository path.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R151): Updated the client example link to point to the correct GitHub repository path.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R151): Updated the license link to point to the correct GitHub repository path.

Version update:

* [`msquic-async/Cargo.toml`](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL3-R6): Incremented the version from `0.1.0` to `0.2.0` and corrected the description capitalization.