### PR TITLE
Call receive_complete for unread buffer

### DIFF
--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -47,6 +47,14 @@ impl StreamRecvBuffer {
     }
 
     pub(crate) fn set_stream(&mut self, stream: Arc<StreamInner>) {
+        trace!(
+            "StreamRecvBuffer({:p}) set StreamInner({:p})",
+            self.buffers
+                .first()
+                .map(|x| x.buffer)
+                .unwrap_or(std::ptr::null_mut()),
+            stream);
+
         self.stream = Some(stream);
     }
 

--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -53,7 +53,8 @@ impl StreamRecvBuffer {
                 .first()
                 .map(|x| x.buffer)
                 .unwrap_or(std::ptr::null_mut()),
-            stream);
+            stream
+        );
 
         self.stream = Some(stream);
     }


### PR DESCRIPTION
This pull request includes several changes to the `msquic-async` library, specifically focusing on improving the handling and logging of stream buffers and stream instances. The most important changes include adding detailed trace logs, managing buffer lengths, and updating the `StreamInnerExclusive` structure.

### Improvements to logging and buffer management:

* [`msquic-async/src/buffer.rs`](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bR50-R57): Added trace logging in the `set_stream` method of `StreamRecvBuffer` to log the buffer and stream pointers.

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R816-R828): Enhanced the `drop` method of `StreamInstance` to log when read is complete and to clear the receive buffers, followed by calling `receive_complete` on the `msquic_stream`.

### Updates to `StreamInnerExclusive` structure:

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R863): Added a new field `recv_len` to the `StreamInnerExclusive` struct to track the total length of received data.

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R923): Initialized the new `recv_len` field to `0` in the `StreamInner` implementation.

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R1051): Incremented the `recv_len` field by the total buffer length when a new buffer is pushed to `recv_buffers`.