### PR TITLE
Filter out empty chunks and final flags

### DIFF
--- a/h3-msquic-async/src/lib.rs
+++ b/h3-msquic-async/src/lib.rs
@@ -613,7 +613,8 @@ impl quic::RecvStream for RecvStream {
 
         let (stream, chunk) = ready!(self.read_chunk_fut.poll(cx));
         self.stream = Some(stream);
-        Poll::Ready(Ok(chunk?))
+        let chunk = chunk?.filter(|x| !x.is_empty() || !x.fin());
+        Poll::Ready(Ok(chunk))
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]


### PR DESCRIPTION
This pull request includes a change to the `impl quic::RecvStream for RecvStream` implementation in the `h3-msquic-async` crate. The change modifies how chunks are processed during polling.

* [`h3-msquic-async/src/lib.rs`](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10L616-R617): Updated the polling logic to filter out empty chunks to return None if they are the final empty chunk (`fin`).