### PR TITLE
Improve read_complete handling for empty buffers and final flags

### DIFF
--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -961,7 +961,7 @@ impl StreamInner {
                 complete_range.start,
                 complete_range.end - complete_range.start
             );
-        
+
             if complete_range.start == 0 && exclusive.read_complete_cursor < complete_range.end {
                 let complete_len = complete_range.end - exclusive.read_complete_cursor;
                 exclusive.read_complete_cursor = complete_range.end;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1196,9 +1196,7 @@ async fn test_read_chunk_empty_fin() {
 
         client_rx.recv().await.expect("recv");
 
-        let _ = poll_fn(|cx| stream.poll_finish_write(cx))
-            .await
-            .unwrap();
+        poll_fn(|cx| stream.poll_finish_write(cx)).await.unwrap();
 
         client_rx.recv().await.expect("recv");
     });


### PR DESCRIPTION
This pull request includes changes to enhance the handling of stream reads and adds a new test for the `Stream::read_chunk()` function. The most important changes are improvements to the `StreamInner` struct in `stream.rs` and the addition of a new test case in `tests.rs`.

Enhancements to stream read handling:

* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L953-R984): Improved the handling of the `complete_len` calculation by using `Option` and simplifying the conditions for setting the `complete_len` value.

Addition of new test case:

* [`msquic-async/src/tests.rs`](diffhunk://#diff-a14c0379907b24a327d7f6260a4a95837a337a92c0c03003d5e506cba080ee5bR1123-R1218): Added a new test case `test_read_chunk_empty_fin` to verify the behavior of `Stream::read_chunk()` when reading an empty chunk with the `fin` flag set.