### PR TITLE
Connection and Listener initialization refactor to remove unnecessary msquic instances

### DIFF
--- a/h3-msquic-async/examples/h3-client.rs
+++ b/h3-msquic-async/examples/h3-client.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
         .load_credential(&cred_config)
         .map_err(|status| anyhow::anyhow!("Configuration::load_credential failed: {}", status))?;
 
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
+    let conn = msquic_async::Connection::new(&registration)?;
     conn.start(&configuration, "127.0.0.1", 8443).await?;
     let h3_conn = h3_msquic_async::Connection::new(conn);
     let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;

--- a/h3-msquic-async/examples/h3-server.rs
+++ b/h3-msquic-async/examples/h3-server.rs
@@ -148,8 +148,7 @@ async fn main() -> anyhow::Result<()> {
             })?;
     };
 
-    let listener =
-        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration)?;
+    let listener = msquic_async::Listener::new(&registration, configuration)?;
 
     let addr: SocketAddr = "127.0.0.1:8443".parse()?;
     listener.start(&[msquic::BufferRef::from("h3")], Some(addr))?;

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
         .load_credential(&cred_config)
         .map_err(|status| anyhow::anyhow!("Configuration::load_credential failed: {}", status))?;
 
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
+    let conn = msquic_async::Connection::new(&registration)?;
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 
     let mut stream = conn

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -138,8 +138,7 @@ async fn main() -> anyhow::Result<()> {
             })?;
     };
 
-    let listener =
-        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration)?;
+    let listener = msquic_async::Listener::new(&registration, configuration)?;
 
     let addr: SocketAddr = "127.0.0.1:4567".parse()?;
     listener.start(&alpn, Some(addr))?;

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -20,10 +20,8 @@ impl Connection {
     /// Create a new connection.
     ///
     /// The connection is not started until `start` is called.
-    pub fn new(
-        msquic_conn: msquic::Connection,
-        registration: &msquic::Registration,
-    ) -> Result<Self, ConnectionError> {
+    pub fn new(registration: &msquic::Registration) -> Result<Self, ConnectionError> {
+        let msquic_conn = msquic::Connection::new();
         let mut inner = Arc::new(ConnectionInner::new(msquic_conn, ConnectionState::Open));
         Arc::get_mut(&mut inner)
             .unwrap()

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -16,10 +16,10 @@ pub struct Listener(Arc<ListenerInner>);
 impl Listener {
     /// Create a new listener.
     pub fn new(
-        msquic_listener: msquic::Listener,
         registration: &msquic::Registration,
         configuration: msquic::Configuration,
     ) -> Result<Self, ListenError> {
+        let msquic_listener = msquic::Listener::new();
         let mut inner = Arc::new(ListenerInner::new(msquic_listener, configuration));
         Arc::get_mut(&mut inner)
             .unwrap()

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -49,8 +49,8 @@ async fn test_connection_start() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
-    let conn1 = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    let conn1 = Connection::new(&registration).unwrap();
     set.spawn(async move {
         let res = conn
             .start(
@@ -134,7 +134,7 @@ async fn test_connection_poll_shutdown() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -198,7 +198,7 @@ async fn test_listener_accept() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         let _ = conn
             .start(
@@ -264,7 +264,7 @@ async fn test_open_outbound_stream() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -358,7 +358,7 @@ async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -480,7 +480,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -614,7 +614,7 @@ async fn test_poll_write() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -691,7 +691,7 @@ async fn test_write_chunk() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -766,7 +766,7 @@ async fn test_write_chunks() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -841,7 +841,7 @@ async fn test_poll_finish_write() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -916,7 +916,7 @@ async fn test_poll_abort_write() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -994,7 +994,7 @@ async fn test_poll_read() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1092,7 +1092,7 @@ async fn test_read_chunk() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1188,7 +1188,7 @@ async fn test_read_chunk_empty_fin() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1289,7 +1289,7 @@ async fn test_read_chunk_multi_recv() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1371,7 +1371,7 @@ async fn test_poll_abort_read() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         conn.start(
             &client_config,
@@ -1504,7 +1504,7 @@ async fn datagram_validation() {
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
     )
     .unwrap();
-    let conn = Connection::new(msquic::Connection::new(), &registration).unwrap();
+    let conn = Connection::new(&registration).unwrap();
     set.spawn(async move {
         let res = conn
             .start(
@@ -1578,7 +1578,7 @@ fn new_server(
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = Listener::new(msquic::Listener::new(), registration, configuration)?;
+    let listener = Listener::new(registration, configuration)?;
     Ok(listener)
 }
 

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1644,7 +1644,7 @@ fn new_server(
     };
 
     configuration.load_credential(&cred_config).unwrap();
-    let listener = Listener::new(msquic::Listener::new(), registration, configuration)?;
+    let listener = Listener::new(registration, configuration)?;
     Ok(listener)
 }
 


### PR DESCRIPTION
This pull request focuses on simplifying the creation of `Connection` and `Listener` objects by removing the need to pass an additional `msquic` object during their instantiation. The changes are applied across multiple example files, the main library, and tests.