### PR TITLE
Changes for the latest MsQuic crate

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -127,6 +127,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: ["", "--features openssl"]
+        exclude:
+          - os: ubuntu-latest
+            features: "--features openssl"
+          - os: macos-latest
+            features: "--features openssl"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -126,14 +126,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        features: ["", "--features tls-schannel"]
-        exclude:
-          - os: ubuntu-latest
-            features: "--features tls-schannel"
-          - os: windows-latest
-            features: ""
-          - os: macos-latest
-            features: "--features tls-schannel"
+        features: ["", "--features openssl"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -125,12 +125,10 @@ jobs:
     needs: [style]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         features: ["", "--features openssl"]
         exclude:
           - os: ubuntu-latest
-            features: "--features openssl"
-          - os: macos-latest
             features: "--features openssl"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -124,11 +124,14 @@ jobs:
     name: Test ${{ matrix.os }}
     needs: [style]
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         features: ["", "--features openssl"]
         exclude:
           - os: ubuntu-latest
+            features: "--features openssl"
+          - os: macos-latest
             features: "--features openssl"
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bytes"
@@ -582,11 +582,11 @@ name = "msquic"
 version = "2.5.0-beta"
 dependencies = [
  "bindgen",
+ "bitflags",
  "c-types",
  "cmake",
  "ctor",
  "libc",
- "serde",
  "socket2",
 ]
 

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 
 [features]
 tracing = ["dep:tracing"]
-tls-schannel = ["msquic-async/tls-schannel"]
+openssl = ["msquic-async/openssl"]
 static = ["msquic-async/static"]
 
 [dependencies]

--- a/h3-msquic-async/examples/h3-server.rs
+++ b/h3-msquic-async/examples/h3-server.rs
@@ -112,17 +112,9 @@ async fn main() -> anyhow::Result<()> {
 
         let context = store.add_cert(&cert_ctx, CertAdd::Always).unwrap();
 
-        let cred_config = msquic::CredentialConfig {
-            cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_CONTEXT,
-            cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-            certificate: msquic::CertificateUnion {
-                context: unsafe { context.as_ptr() },
-            },
-            principle: ptr::null(),
-            reserved: ptr::null(),
-            async_handler: None,
-            allowed_cipher_suites: 0,
-        };
+        let cred_config = msquic::CredentialConfig::new().set_credential(
+            msquic::Credential::CertificateContext(unsafe { context.as_ptr() }),
+        );
 
         configuration
             .load_credential(&cred_config)

--- a/h3-msquic-async/examples/h3-server.rs
+++ b/h3-msquic-async/examples/h3-server.rs
@@ -1,5 +1,5 @@
 /// This file is based on the `server.rs` example from the `h3` crate.
-use std::{net::SocketAddr, path::PathBuf, ptr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use argh::FromArgs;
 use bytes::{Bytes, BytesMut};
@@ -31,8 +31,8 @@ async fn main() -> anyhow::Result<()> {
     let cmd_opts: CmdOptions = argh::from_env();
     let root = Arc::new(cmd_opts.root);
 
-    let registration = msquic::Registration::new(ptr::null())
-        .map_err(|status| anyhow::anyhow!("Registration::new failed: {}", status))?;
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+
     let alpn = [msquic::BufferRef::from("h3")];
 
     // create msquic-async listener
@@ -47,12 +47,11 @@ async fn main() -> anyhow::Result<()> {
                 .set_DatagramReceiveEnabled()
                 .set_StreamMultiReceiveEnabled(),
         ),
-    )
-    .map_err(|status| anyhow::anyhow!("Configuration::new failed: {}", status))?;
+    )?;
 
-    #[cfg(not(feature = "tls-schannel"))]
+    #[cfg(any(not(windows), feature = "openssl"))]
     {
-        use std::{ffi::CString, io::Write};
+        use std::io::Write;
         use tempfile::NamedTempFile;
 
         let cert = include_bytes!("cert.pem");
@@ -61,37 +60,21 @@ async fn main() -> anyhow::Result<()> {
         let mut cert_file = NamedTempFile::new()?;
         cert_file.write_all(cert)?;
         let cert_path = cert_file.into_temp_path();
-        let cert_path = CString::new(cert_path.to_path_buf().as_os_str().as_encoded_bytes())?;
+        let cert_path = cert_path.to_string_lossy().into_owned();
 
         let mut key_file = NamedTempFile::new()?;
         key_file.write_all(key)?;
         let key_path = key_file.into_temp_path();
-        let key_path = CString::new(key_path.to_path_buf().as_os_str().as_encoded_bytes())?;
+        let key_path = key_path.to_string_lossy().into_owned();
 
-        let certificate_file = msquic::CertificateFile {
-            private_key_file: key_path.as_ptr(),
-            certificate_file: cert_path.as_ptr(),
-        };
+        let cred_config = msquic::CredentialConfig::new().set_credential(
+            msquic::Credential::CertificateFile(msquic::CertificateFile::new(key_path, cert_path)),
+        );
 
-        let cred_config = msquic::CredentialConfig {
-            cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_FILE,
-            cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-            certificate: msquic::CertificateUnion {
-                file: &certificate_file,
-            },
-            principle: ptr::null(),
-            reserved: ptr::null(),
-            async_handler: None,
-            allowed_cipher_suites: 0,
-        };
-        configuration
-            .load_credential(&cred_config)
-            .map_err(|status| {
-                anyhow::anyhow!("Configuration::load_credential failed: {}", status)
-            })?;
+        configuration.load_credential(&cred_config)?;
     }
 
-    #[cfg(feature = "tls-schannel")]
+    #[cfg(all(windows, not(feature = "openssl")))]
     {
         use schannel::cert_context::{CertContext, KeySpec};
         use schannel::cert_store::{CertAdd, Memory};

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [features]
-default = ["tokio", "static"]
+default = ["tokio"]
 openssl = ["msquic/openssl"]
 static = ["msquic/static"]
 

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -19,8 +19,8 @@ include = [
 ]
 
 [features]
-default = ["tokio"]
-tls-schannel = ["msquic/schannel"]
+default = ["tokio", "static"]
+openssl = ["msquic/openssl"]
 static = ["msquic/static"]
 
 [dependencies]

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -1,4 +1,4 @@
-use std::{mem, net::SocketAddr, ptr};
+use std::{mem, net::SocketAddr};
 
 use argh::FromArgs;
 use msquic_async::msquic;
@@ -20,8 +20,7 @@ async fn main() -> anyhow::Result<()> {
 
     let _cmd_opts: CmdOptions = argh::from_env();
 
-    let registration = msquic::Registration::new(ptr::null())
-        .map_err(|status| anyhow::anyhow!("Registration::new failed: {}", status))?;
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("sample")];
 
@@ -37,12 +36,11 @@ async fn main() -> anyhow::Result<()> {
                 .set_DatagramReceiveEnabled()
                 .set_StreamMultiReceiveEnabled(),
         ),
-    )
-    .map_err(|status| anyhow::anyhow!("Configuration::new failed: {}", status))?;
+    )?;
 
-    #[cfg(not(feature = "tls-schannel"))]
+    #[cfg(any(not(windows), feature = "openssl"))]
     {
-        use std::{ffi::CString, io::Write};
+        use std::io::Write;
         use tempfile::NamedTempFile;
 
         let cert = include_bytes!("cert.pem");
@@ -51,37 +49,21 @@ async fn main() -> anyhow::Result<()> {
         let mut cert_file = NamedTempFile::new()?;
         cert_file.write_all(cert)?;
         let cert_path = cert_file.into_temp_path();
-        let cert_path = CString::new(cert_path.to_path_buf().as_os_str().as_encoded_bytes())?;
+        let cert_path = cert_path.to_string_lossy().into_owned();
 
         let mut key_file = NamedTempFile::new()?;
         key_file.write_all(key)?;
         let key_path = key_file.into_temp_path();
-        let key_path = CString::new(key_path.to_path_buf().as_os_str().as_encoded_bytes())?;
+        let key_path = key_path.to_string_lossy().into_owned();
 
-        let certificate_file = msquic::CertificateFile {
-            private_key_file: key_path.as_ptr(),
-            certificate_file: cert_path.as_ptr(),
-        };
+        let cred_config = msquic::CredentialConfig::new().set_credential(
+            msquic::Credential::CertificateFile(msquic::CertificateFile::new(key_path, cert_path)),
+        );
 
-        let cred_config = msquic::CredentialConfig {
-            cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_FILE,
-            cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-            certificate: msquic::CertificateUnion {
-                file: &certificate_file,
-            },
-            principle: ptr::null(),
-            reserved: ptr::null(),
-            async_handler: None,
-            allowed_cipher_suites: 0,
-        };
-        configuration
-            .load_credential(&cred_config)
-            .map_err(|status| {
-                anyhow::anyhow!("Configuration::load_credential failed: {}", status)
-            })?;
+        configuration.load_credential(&cred_config)?;
     }
 
-    #[cfg(feature = "tls-schannel")]
+    #[cfg(all(windows, not(feature = "openssl")))]
     {
         use schannel::cert_context::{CertContext, KeySpec};
         use schannel::cert_store::{CertAdd, Memory};

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -101,23 +101,11 @@ async fn main() -> anyhow::Result<()> {
 
         let context = store.add_cert(&cert_ctx, CertAdd::Always).unwrap();
 
-        let cred_config = msquic::CredentialConfig {
-            cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_CONTEXT,
-            cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-            certificate: msquic::CertificateUnion {
-                context: unsafe { context.as_ptr() },
-            },
-            principle: ptr::null(),
-            reserved: ptr::null(),
-            async_handler: None,
-            allowed_cipher_suites: 0,
-        };
+        let cred_config = msquic::CredentialConfig::new().set_credential(
+            msquic::Credential::CertificateContext(unsafe { context.as_ptr() }),
+        );
 
-        configuration
-            .load_credential(&cred_config)
-            .map_err(|status| {
-                anyhow::anyhow!("Configuration::load_credential failed: {}", status)
-            })?;
+        configuration.load_credential(&cred_config)?;
     };
 
     let listener = msquic_async::Listener::new(&registration, configuration)?;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1618,17 +1618,9 @@ fn new_server(
 
     let context = store.add_cert(&cert_ctx, CertAdd::Always).unwrap();
 
-    let cred_config = msquic::CredentialConfig {
-        cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_CONTEXT,
-        cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-        certificate: msquic::CertificateUnion {
-            context: unsafe { context.as_ptr() },
-        },
-        principle: ptr::null(),
-        reserved: ptr::null(),
-        async_handler: None,
-        allowed_cipher_suites: 0,
-    };
+    let cred_config = msquic::CredentialConfig::new().set_credential(
+        msquic::Credential::CertificateContext(unsafe { context.as_ptr() }),
+    );
 
     configuration.load_credential(&cred_config).unwrap();
     let listener = Listener::new(registration, configuration)?;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -5,7 +5,6 @@ use super::{
 use std::future::poll_fn;
 use std::mem;
 use std::net::SocketAddr;
-use std::ptr;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -23,7 +22,7 @@ async fn test_connection_start() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -42,6 +41,7 @@ async fn test_connection_start() {
 
         listener.stop().await.unwrap();
         server_tx.send(()).await.unwrap();
+        drop(listener);
     });
 
     let client_config = new_client_config(
@@ -100,7 +100,7 @@ async fn test_connection_start() {
 async fn test_connection_poll_shutdown() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -143,6 +143,7 @@ async fn test_connection_poll_shutdown() {
         )
         .await
         .unwrap();
+        // conn.shutdown(1).unwrap();
         let res = poll_fn(|cx| conn.poll_shutdown(cx, 1)).await;
         assert!(res.is_ok());
 
@@ -165,7 +166,7 @@ async fn test_connection_poll_shutdown() {
 /// Test for ['Listener::accept()']
 #[test(tokio::test)]
 async fn test_listener_accept() {
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -227,7 +228,7 @@ async fn test_listener_accept() {
 async fn test_open_outbound_stream() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -319,7 +320,7 @@ async fn test_open_outbound_stream() {
 async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -442,7 +443,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -582,7 +583,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
 async fn test_poll_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -659,7 +660,7 @@ async fn test_poll_write() {
 async fn test_write_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -734,7 +735,7 @@ async fn test_write_chunk() {
 async fn test_write_chunks() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -809,7 +810,7 @@ async fn test_write_chunks() {
 async fn test_poll_finish_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -882,7 +883,7 @@ async fn test_poll_finish_write() {
 async fn test_poll_abort_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -957,7 +958,7 @@ async fn test_poll_abort_write() {
 async fn test_poll_read() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1034,7 +1035,7 @@ async fn test_poll_read() {
 async fn test_read_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1138,7 +1139,7 @@ async fn test_read_chunk() {
 async fn test_read_chunk_empty_fin() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1232,7 +1233,7 @@ async fn test_read_chunk_empty_fin() {
 async fn test_read_chunk_multi_recv() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1336,7 +1337,7 @@ async fn test_poll_abort_read() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1470,7 +1471,7 @@ async fn datagram_validation() {
     //let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(ptr::null()).unwrap();
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1535,12 +1536,11 @@ async fn datagram_validation() {
     });
 }
 
-#[cfg(not(feature = "tls-schannel"))]
+#[cfg(any(not(windows), feature = "openssl"))]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,
 ) -> Result<Listener> {
-    use std::ffi::CString;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -1553,36 +1553,23 @@ fn new_server(
     let mut cert_file = NamedTempFile::new().unwrap();
     cert_file.write_all(cert).unwrap();
     let cert_path = cert_file.into_temp_path();
-    let cert_path = CString::new(cert_path.to_str().unwrap().as_bytes()).unwrap();
+    let cert_path = cert_path.to_string_lossy().into_owned();
 
     let mut key_file = NamedTempFile::new().unwrap();
     key_file.write_all(key).unwrap();
     let key_path = key_file.into_temp_path();
-    let key_path = CString::new(key_path.to_str().unwrap().as_bytes()).unwrap();
+    let key_path = key_path.to_string_lossy().into_owned();
 
-    let certificate_file = msquic::CertificateFile {
-        private_key_file: key_path.as_ptr(),
-        certificate_file: cert_path.as_ptr(),
-    };
-
-    let cred_config = msquic::CredentialConfig {
-        cred_type: msquic::CREDENTIAL_TYPE_CERTIFICATE_FILE,
-        cred_flags: msquic::CREDENTIAL_FLAG_NONE,
-        certificate: msquic::CertificateUnion {
-            file: &certificate_file,
-        },
-        principle: ptr::null(),
-        reserved: ptr::null(),
-        async_handler: None,
-        allowed_cipher_suites: 0,
-    };
+    let cred_config = msquic::CredentialConfig::new().set_credential(
+        msquic::Credential::CertificateFile(msquic::CertificateFile::new(key_path, cert_path)),
+    );
 
     configuration.load_credential(&cred_config).unwrap();
     let listener = Listener::new(registration, configuration)?;
     Ok(listener)
 }
 
-#[cfg(feature = "tls-schannel")]
+#[cfg(all(windows, not(feature = "openssl")))]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,
@@ -1654,8 +1641,8 @@ fn new_client_config(
 ) -> Result<msquic::Configuration> {
     let alpn = [msquic::BufferRef::from("test")];
     let configuration = msquic::Configuration::new(registration, &alpn, Some(settings)).unwrap();
-    let mut cred_config = msquic::CredentialConfig::new_client();
-    cred_config.cred_flags |= msquic::CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION;
+    let cred_config = msquic::CredentialConfig::new_client()
+        .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
     configuration.load_credential(&cred_config).unwrap();
     Ok(configuration)
 }


### PR DESCRIPTION
This pull request includes significant updates to the `msquic` and `msquic-async` projects, focusing on improving the configuration and credential management, as well as updating dependencies and simplifying code. The most important changes include replacing the `tls-schannel` feature with `openssl`, updating the `msquic` submodule, and refactoring the connection handling code.

### Dependency and Feature Updates:

* [`Cargo.toml`](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL23-R23): Replaced the `tls-schannel` feature with `openssl` in both `h3-msquic-async` and `msquic-async` projects. [[1]](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL23-R23) [[2]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL23-R23)

### Example Client and Server Updates:

* `h3-client.rs`, `h3-server.rs`, `client.rs`, `server.rs`: Updated the registration and configuration initialization to use `msquic::RegistrationConfig::default()` and refactored the credential configuration to use `msquic::CredentialConfig` methods. [[1]](diffhunk://#diff-5281411e79c196393526166634002eb5ac75d3f84b1ea158be6211911cb05c21L18-R17) [[2]](diffhunk://#diff-5281411e79c196393526166634002eb5ac75d3f84b1ea158be6211911cb05c21L33-R34) [[3]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acL34-R35) [[4]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acL50-R54) [[5]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4L15-L19) [[6]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4L31-R31) [[7]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL23-R23) [[8]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL40-R43)

### Submodule Update:

* [`msquic`](diffhunk://#diff-d55f28b0b6d2e03f0106c120559fabb862b4d1cb3dec9e3aa65d02d8fd958b5eL1-R1): Updated the submodule to the latest commit.

### Connection Handling Improvements:

* [`connection.rs`](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L24-R46): Refactored the connection handling to use `RwLock` for `msquic_conn` and updated the callback handler implementation. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L24-R46) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R80-R83) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L251-R251) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L286-R293) [[5]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R322-R325) [[6]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R356-R359)