### PR TITLE
Changes for use of the latest MsQuic crate

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -543,8 +543,7 @@ impl ConnectionInner {
         stream: msquic::StreamRef,
         flags: msquic::StreamOpenFlags,
     ) -> Result<(), msquic::Status> {
-        let stream_type = if (flags
-            & msquic::StreamOpenFlags::UNIDIRECTIONAL)
+        let stream_type = if (flags & msquic::StreamOpenFlags::UNIDIRECTIONAL)
             == msquic::StreamOpenFlags::UNIDIRECTIONAL
         {
             StreamType::Unidirectional
@@ -558,7 +557,9 @@ impl ConnectionInner {
         );
 
         let stream = Stream::from_raw(unsafe { stream.as_raw() }, stream_type);
-        if (flags & msquic::StreamOpenFlags::UNIDIRECTIONAL) == msquic::StreamOpenFlags::UNIDIRECTIONAL {
+        if (flags & msquic::StreamOpenFlags::UNIDIRECTIONAL)
+            == msquic::StreamOpenFlags::UNIDIRECTIONAL
+        {
             if let (Some(read_stream), None) = stream.split() {
                 let mut exclusive = self.exclusive.lock().unwrap();
                 exclusive.inbound_uni_streams.push_back(read_stream);
@@ -640,8 +641,7 @@ impl ConnectionInner {
             state
         );
         match state {
-            msquic::DatagramSendState::Sent
-            | msquic::DatagramSendState::Canceled => {
+            msquic::DatagramSendState::Sent | msquic::DatagramSendState::Canceled => {
                 let mut write_buf = unsafe { WriteBuffer::from_raw(client_context) };
                 let mut exclusive = self.exclusive.lock().unwrap();
                 write_buf.reset();

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1117,7 +1117,7 @@ impl StreamInner {
         let recv_buffer = StreamRecvBuffer::new(
             absolute_offset as usize,
             buffers,
-            (flags & msquic::ReceiveFlags::FIN) == msquic::ReceiveFlags::FIN
+            (flags & msquic::ReceiveFlags::FIN) == msquic::ReceiveFlags::FIN,
         );
 
         let _ = Arc::into_raw(arc_inner);


### PR DESCRIPTION
This pull request includes several changes to the `msquic-async` library to update the usage of constants and flags from the `msquic` library. The changes primarily involve replacing the old `msquic::ffi` constants with the new `msquic` enums and flags.

Updates to constants and flags:

* [`msquic-async/src/connection.rs`](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L253-R253): Updated various `msquic::ffi` constants to the new `msquic` enums and flags, such as `msquic::SEND_FLAG_NONE` to `msquic::SendFlags::NONE` and `msquic::CONNECTION_SHUTDOWN_FLAG_NONE` to `msquic::ConnectionShutdownFlags::NONE`. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L253-R253) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L295-R295) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L326-R326) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L360-R360) [[5]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L396-R396) [[6]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L544-R548) [[7]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L561-R561) [[8]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L617-R617) [[9]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L635-R644)
* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L35-R37): Updated various `msquic::ffi` constants to the new `msquic` enums and flags, such as `msquic::STREAM_OPEN_FLAG_UNIDIRECTIONAL` to `msquic::StreamOpenFlags::UNIDIRECTIONAL` and `msquic::STREAM_SHUTDOWN_FLAG_GRACEFUL` to `msquic::StreamShutdownFlags::GRACEFUL`. [[1]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L35-R37) [[2]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L103-R108) [[3]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L644-R644) [[4]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L666-R666) [[5]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L698-R698) [[6]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L745-R745) [[7]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L783-R783) [[8]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L812-R812) [[9]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L850-R850) [[10]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L896-R898) [[11]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L1104-R1120)

Additionally, the submodule reference for `msquic` was updated to a new commit.

* [`msquic`](diffhunk://#diff-d55f28b0b6d2e03f0106c120559fabb862b4d1cb3dec9e3aa65d02d8fd958b5eL1-R1): Updated submodule commit reference.