### PR TITLE
Bump h3 from 0.06 to 0.07

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,9 +429,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h3"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7675a0963b47a6d12fe44c279918b4ffb19baee838ac37f48d2722ad5bc6ab"
+checksum = "7dfb059a4f28a66f186ed16ad912d142f490676acba59353831d7cb45a96b0d3"
 dependencies = [
  "bytes",
  "fastrand",
@@ -439,6 +439,17 @@ dependencies = [
  "http",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "h3-datagram"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c058c00e0ff53a456ad97cc0df2d0f44fbe7a2c11c9eca87c25471ca68fa1c"
+dependencies = [
+ "bytes",
+ "h3",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -450,6 +461,7 @@ dependencies = [
  "bytes",
  "futures",
  "h3",
+ "h3-datagram",
  "http",
  "msquic-async",
  "schannel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ argh = "0.1.10"
 bytes = "1.5.0"
 futures = "0.3.30"
 futures-io = "0.3.30"
-h3 = "0.0.6"
+h3 = "0.0.7"
 #h3 = { git = "https://github.com/hyperium/h3.git" }
+h3-datagram = "0.0.1"
 http = "1"
 libc = "0.2.153"
-#msquic = "2.5.0-beta3"
-msquic = { path = "./msquic" }
-msquic-async = { path = "./msquic-async" }
+msquic = { version = "2.5.0-beta", path = "./msquic" }
+msquic-async = { version = "0.2.0", path = "./msquic-async" }
 rangemap = "1.5.1"
 schannel = "0.1.27"
 tempfile = "3.10.1"

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [features]
 tracing = ["dep:tracing"]
+datagram = ["dep:h3-datagram"]
 openssl = ["msquic-async/openssl"]
 static = ["msquic-async/static"]
 
@@ -27,6 +28,7 @@ static = ["msquic-async/static"]
 bytes = { workspace = true }
 futures = { workspace = true }
 h3 = { workspace = true }
+h3-datagram = { workspace = true, optional = true }
 msquic-async = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-util = { workspace = true }


### PR DESCRIPTION
This pull request includes several updates to the dependencies and codebase to support the new `h3-datagram` feature in the `h3-msquic-async` crate. The changes include updating dependency versions, adding conditional compilation for the new feature, and modifying the `Connection` struct and its implementations.

Dependency updates and feature additions:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R20): Updated `h3` to version `0.0.7` and added the `h3-datagram` dependency. Updated `msquic` and `msquic-async` dependencies to include version information.
* [`h3-msquic-async/Cargo.toml`](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cR23-R31): Added the `datagram` feature and made `h3-datagram` an optional dependency.

Code modifications for `h3-datagram` support:

* [`h3-msquic-async/src/lib.rs`](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10L2-R13): Added conditional imports and usage of `h3_datagram` and `quic_traits` based on the `datagram` feature.
* [`h3-msquic-async/src/lib.rs`](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10R41): Updated the `Connection` struct to include a `datagrams` field when the `datagram` feature is enabled. [[1]](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10R41) [[2]](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10R58)
* [`h3-msquic-async/src/lib.rs`](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10L361-R365): Implemented `quic_traits::SendDatagramExt` and `quic_traits::RecvDatagramExt` for the `Connection` struct conditionally based on the `datagram` feature. [[1]](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10L361-R365) [[2]](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10L378-R383)