### PR TITLE
Add get_{local,remote}_addr

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -3,6 +3,7 @@ use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamTy
 
 use std::collections::VecDeque;
 use std::future::Future;
+use std::net::SocketAddr;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, RwLock};
@@ -363,6 +364,34 @@ impl Connection {
             _ => {}
         }
         Ok(())
+    }
+
+    /// Get the local address of the connection.
+    pub fn get_local_addr(&self) -> Result<SocketAddr, ConnectionError> {
+        self.0
+            .shared
+            .msquic_conn
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("msquic_conn set")
+            .get_local_addr()
+            .map(|addr| addr.as_socket().expect("socket addr"))
+            .map_err(ConnectionError::OtherError)
+    }
+
+    /// Get the remote address of the connection.
+    pub fn get_remote_addr(&self) -> Result<SocketAddr, ConnectionError> {
+        self.0
+            .shared
+            .msquic_conn
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("msquic_conn set")
+            .get_remote_addr()
+            .map(|addr| addr.as_socket().expect("socket addr"))
+            .map_err(ConnectionError::OtherError)
     }
 }
 

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1412,6 +1412,146 @@ async fn test_poll_abort_read() {
     });
 }
 
+/// Test for ['Connection::start()']
+#[test(tokio::test)]
+async fn test_get_local_addr() {
+    let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let conn = listener.accept().await.unwrap();
+        let res = conn.get_local_addr();
+        assert!(res.is_ok());
+        let addr = res.unwrap();
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert_eq!(addr.ip(), addr1.ip());
+        server_rx.recv().await.unwrap();
+        server_tx.send(()).await.unwrap();
+    });
+
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    set.spawn(async move {
+        let res = conn.get_local_addr();
+        assert!(res.is_err());
+        let res = conn
+            .start(
+                &client_config,
+                &format!("{}", server_addr.ip()),
+                server_addr.port(),
+            )
+            .await;
+        assert!(res.is_ok());
+        let res = conn.get_local_addr();
+        assert!(res.is_ok());
+        let addr = res.unwrap();
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert_eq!(addr.ip(), addr1.ip());
+        client_tx.send(()).await.unwrap();
+        client_rx.recv().await.unwrap();
+
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
+/// Test for ['Connection::start()']
+#[test(tokio::test)]
+async fn test_get_remote_addr() {
+    let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let conn = listener.accept().await.unwrap();
+        let res = conn.get_remote_addr();
+        assert!(res.is_ok());
+        let addr = res.unwrap();
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert_eq!(addr.ip(), addr1.ip());
+        server_rx.recv().await.unwrap();
+        server_tx.send(()).await.unwrap();
+    });
+
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    set.spawn(async move {
+        let res = conn.get_remote_addr();
+        assert!(res.is_err());
+        let res = conn
+            .start(
+                &client_config,
+                &format!("{}", server_addr.ip()),
+                server_addr.port(),
+            )
+            .await;
+        assert!(res.is_ok());
+        let res = conn.get_remote_addr();
+        assert!(res.is_ok());
+        let addr = res.unwrap();
+        let addr1: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert_eq!(addr.ip(), addr1.ip());
+        client_tx.send(()).await.unwrap();
+        client_rx.recv().await.unwrap();
+
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
 #[test]
 fn test_stream_recv_buffers() {
     let buffers = vec![

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1466,7 +1466,6 @@ async fn test_get_local_addr() {
         assert_eq!(addr.ip(), addr1.ip());
         client_tx.send(()).await.unwrap();
         client_rx.recv().await.unwrap();
-
     });
 
     let mut results = Vec::new();
@@ -1536,7 +1535,6 @@ async fn test_get_remote_addr() {
         assert_eq!(addr.ip(), addr1.ip());
         client_tx.send(()).await.unwrap();
         client_rx.recv().await.unwrap();
-
     });
 
     let mut results = Vec::new();


### PR DESCRIPTION
This pull request introduces new functionality to retrieve the local and remote addresses of a connection in the `msquic-async` crate, along with corresponding tests to validate these features. 

The most important changes include:

### New Functionality:
* Added `get_local_addr` and `get_remote_addr` methods to the `Connection` struct to retrieve the local and remote addresses of a connection. (`msquic-async/src/connection.rs`)

### Testing:
* Added `test_get_local_addr` and `test_get_remote_addr` async tests to validate the new methods for retrieving connection addresses. (`msquic-async/src/tests.rs`)

### Imports:
* Added the `SocketAddr` import to support the new address retrieval functionality. (`msquic-async/src/connection.rs`)