### PR TITLE
Refactor Listener, Connection, and Stream

### DIFF
--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -1,4 +1,4 @@
-use crate::stream::StreamInner;
+use crate::stream::StreamInstance;
 
 use std::io::IoSlice;
 use std::ops::Range;
@@ -13,7 +13,7 @@ use tracing::trace;
 ///
 /// It implements [`bytes::Buf`] and is backed by a list of [`msquic::ffi::QUIC_BUFFER`].
 pub struct StreamRecvBuffer {
-    stream: Option<Arc<StreamInner>>,
+    stream: Option<Arc<StreamInstance>>,
     buffers: Vec<msquic::ffi::QUIC_BUFFER>,
     offset: usize,
     len: usize,
@@ -50,7 +50,7 @@ impl StreamRecvBuffer {
         buf
     }
 
-    pub(crate) fn set_stream(&mut self, stream: Arc<StreamInner>) {
+    pub(crate) fn set_stream(&mut self, stream: Arc<StreamInstance>) {
         trace!(
             "StreamRecvBuffer({:p}) set StreamInner({:p})",
             self.buffers

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1131,6 +1131,7 @@ impl StreamInner {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_event_shutdown_complete(
         &self,
         msquic_stream: msquic::StreamRef,

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -459,13 +459,13 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
     set.spawn(async move {
         let conn = listener.accept().await.unwrap();
 
-        let _ = conn.accept_inbound_stream().await.unwrap();
-        let _ = conn.accept_inbound_stream().await.unwrap();
-        let _ = conn.accept_inbound_stream().await.unwrap();
+        let _a = conn.accept_inbound_stream().await.unwrap();
+        let _b = conn.accept_inbound_stream().await.unwrap();
+        let _c = conn.accept_inbound_stream().await.unwrap();
 
-        let _ = conn.accept_inbound_uni_stream().await.unwrap();
-        let _ = conn.accept_inbound_uni_stream().await.unwrap();
-        let _ = conn.accept_inbound_uni_stream().await.unwrap();
+        let _d = conn.accept_inbound_uni_stream().await.unwrap();
+        let _e = conn.accept_inbound_uni_stream().await.unwrap();
+        let _f = conn.accept_inbound_uni_stream().await.unwrap();
 
         server_rx.recv().await.unwrap();
         server_tx.send(()).await.unwrap();


### PR DESCRIPTION
This pull request includes changes primarily focused on refactoring and simplifying the codebase by removing unnecessary synchronization mechanisms and improving the structure of various components. The most important changes include switching from `StreamInner` to `StreamInstance`, removing `RwLock` usage, and refactoring `Connection` and `Listener` structs.

Refactoring and simplification:

* [`msquic-async/src/buffer.rs`](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bL1-R1): Replaced `StreamInner` with `StreamInstance` and updated related methods accordingly. [[1]](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bL1-R1) [[2]](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bL16-R16) [[3]](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bL53-R53)
* [`msquic-async/src/connection.rs`](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L9-R9): Removed `RwLock` and refactored `ConnectionInstance` to hold `msquic_conn` directly. Updated methods to use the new structure. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L9-R9) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L33-R34) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L45-R45) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L77-L82) [[5]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L243-R236) [[6]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L285-R271) [[7]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L319-L324) [[8]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L353-L358) [[9]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L370-L375) [[10]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L384-L418) [[11]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L435-L438) [[12]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L455-L457) [[13]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L818-R768) [[14]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L837-R787) [[15]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L854-R804)
* [`msquic-async/src/listener.rs`](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L6-R16): Removed `RwLock` and refactored `Listener` to hold `msquic_listener` directly. Updated methods to use the new structure. [[1]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L6-R16) [[2]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L34-R41) [[3]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L45-R58) [[4]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L74-R73) [[5]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L103-R102) [[6]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L121-R127) [[7]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L150-R136) [[8]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L182) [[9]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L204-R177) [[10]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L268-L271)
* [`msquic-async/src/stream.rs`](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L7): Updated `Stream` to use the new `StreamInstance` structure and removed unnecessary synchronization. [[1]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L7) [[2]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L51-R59)