### PR TITLE
bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ h3-datagram = "0.0.2"
 http = "1"
 libc = "0.2.153"
 msquic = { version = "2.6.0-beta", path = "./msquic" }
-msquic-async = { version = "0.2.0", path = "./msquic-async" }
+msquic-async = { version = "0.3.0", path = "./msquic-async" }
 rangemap = "1.5.1"
 schannel = "0.1.27"
 tempfile = "3.10.1"

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3-msquic-async"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic-Async based library for using h3"
@@ -19,7 +19,7 @@ include = [
 ]
 
 [features]
-default = ["datagram"]
+default = []
 tracing = ["dep:tracing"]
 datagram = ["dep:h3-datagram"]
 quictls = ["msquic-async/quictls"]

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic-async"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic based quic library that supports async operation"


### PR DESCRIPTION
This pull request updates dependencies and version numbers across several `Cargo.toml` files to align with new releases and modifies default feature configurations for the `h3-msquic-async` crate.

### Dependency and version updates:

* Updated the `msquic-async` dependency in `Cargo.toml` from version `0.2.0` to `0.3.0` to reflect the latest release. (`h3-datagram = "0.0.2"` file, [Cargo.tomlL19-R19](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L19-R19))
* Bumped the version of the `h3-msquic-async` crate from `0.1.0` to `0.2.0`. (`h3-msquic-async/Cargo.toml`, [h3-msquic-async/Cargo.tomlL3-R3](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL3-R3))
* Bumped the version of the `msquic-async` crate from `0.2.0` to `0.3.0`. (`msquic-async/Cargo.toml`, [msquic-async/Cargo.tomlL3-R3](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL3-R3))

### Feature configuration changes:

* Removed the `datagram` feature from the default features in the `h3-msquic-async` crate to allow more explicit feature selection. (`h3-msquic-async/Cargo.toml`, [h3-msquic-async/Cargo.tomlL22-R22](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL22-R22))