### PR TITLE
Add checks in dgram_send()

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -275,7 +275,7 @@ impl Connection {
         if buf.len() > exclusive.dgram_max_send_length as usize {
             return Err(DgramSendError::TooBig);
         }
-        
+
         let mut write_buf = exclusive.write_pool.pop().unwrap_or(WriteBuffer::new());
         let _ = write_buf.put_zerocopy(buf);
         let buffers = unsafe {


### PR DESCRIPTION
This pull request introduces support for managing datagram send capabilities in the `msquic-async` library. It adds checks for datagram send eligibility and size limits, alongside new fields and initialization logic to track these properties.

### Datagram send capability management:

* `msquic-async/src/connection.rs`:
  - Added checks in the `Connection` implementation to return errors if datagram sending is disabled (`DgramSendError::Denied`) or if the datagram size exceeds the maximum allowed (`DgramSendError::TooBig`).
  - Introduced new fields `dgram_send_enabled` and `dgram_max_send_length` in the `ConnectionInnerExclusive` struct to track datagram send state and size limits.
  - Initialized `dgram_send_enabled` to `false` and `dgram_max_send_length` to `0` in the `ConnectionInner` constructor.
  - Updated the `ConnectionInner` implementation to set the `dgram_send_enabled` and `dgram_max_send_length` fields when configuring datagram send capabilities.