### PR TITLE
Update README

### DIFF
--- a/h3-msquic-async/README.md
+++ b/h3-msquic-async/README.md
@@ -7,16 +7,10 @@ Note that [MsQuic](https://github.com/microsoft/msquic), which is used to implem
 needs to be built and linked. This is done automatically when building h3-msquic-async, but
 requires the cmake command to be available during the build process.
 
-### Windows
+### Windows, Linux, MacOS
 Add h3-msquic-async in dependencies of your Cargo.toml.
 ```toml
-h3-msquic-async = { version = "0.1.0", features = ["tls-schannel"] }
-```
-
-### Linux, MacOS
-Add h3-msquic-async in dependencies of your Cargo.toml.
-```toml
-h3-msquic-async = { version = "0.1.0" }
+h3-msquic-async = { version = "0.2.0" }
 ```
 
 The [examples](./examples/) directory can help get started.
@@ -24,11 +18,10 @@ The [examples](./examples/) directory can help get started.
 ### Server
 
 ```rust
-    let listener =
-        msquic_async::Listener::new(msquic::Listener::new(), &registration, configuration)?;
+    let listener = msquic_async::Listener::new(&registration, configuration)?;
 
     let addr: SocketAddr = "127.0.0.1:8443".parse()?;
-    listener.start(&[msquic::Buffer::from("h3")], Some(addr))?;
+    listener.start(&[msquic::BufferRef::from("h3")], Some(addr))?;
     let server_addr = listener.local_addr()?;
 
     info!("listening on {}", server_addr);
@@ -39,10 +32,18 @@ The [examples](./examples/) directory can help get started.
         info!("new connection established");
         let root = root.clone();
         tokio::spawn(async move {
-            let mut h3_conn = h3::server::Connection::new(h3_msquic_async::Connection::new(conn)).await?;
+            let mut h3_conn =
+                h3::server::Connection::new(h3_msquic_async::Connection::new(conn)).await?;
             loop {
                 match h3_conn.accept().await {
-                    Ok(Some((req, stream))) => {
+                    Ok(Some(req_resolver)) => {
+                        let (req, stream) = match req_resolver.resolve_request().await {
+                            Ok(req) => req,
+                            Err(err) => {
+                                error!("error resolving request: {}", err);
+                                continue;
+                            }
+                        };
                         info!("new request: {:#?}", req);
 
                         let root = root.clone();
@@ -61,10 +62,7 @@ The [examples](./examples/) directory can help get started.
 
                     Err(err) => {
                         error!("error on accept {}", err);
-                        match err.get_error_level() {
-                            ErrorLevel::ConnectionError => break,
-                            ErrorLevel::StreamError => continue,
-                        }
+                        break;
                     }
                 }
             }
@@ -78,14 +76,13 @@ You can find a full server example in [`examples/h3-server.rs`](./examples/h3-se
 ### Client
 
 ``` rust
-    let conn = msquic_async::Connection::new(msquic::Connection::new(), &registration)?;
+    let conn = msquic_async::Connection::new(&registration)?;
     conn.start(&configuration, "127.0.0.1", 8443).await?;
     let h3_conn = h3_msquic_async::Connection::new(conn);
     let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;
 
     let drive = async move {
-        future::poll_fn(|cx| driver.poll_close(cx)).await?;
-        Ok::<(), anyhow::Error>(())
+        Err::<(), ConnectionError>(future::poll_fn(|cx| driver.poll_close(cx)).await)
     };
     let request = async move {
         info!("sending request ...");
@@ -120,8 +117,28 @@ You can find a full server example in [`examples/h3-server.rs`](./examples/h3-se
     };
 
     let (req_res, drive_res) = tokio::join!(request, drive);
-    req_res?;
-    drive_res?;
+    if let Err(err) = req_res {
+        match err.downcast::<StreamError>() {
+            Ok(err) => {
+                if err.is_h3_no_error() {
+                    info!("connection closed with H3_NO_ERROR");
+                } else {
+                    error!("request failed: {:?}", err);
+                }
+            }
+            Err(err) => {
+                error!("request failed: {:?}", err);
+            }
+        }
+    }
+    if let Err(err) = drive_res {
+        if err.is_h3_no_error() {
+            info!("connection closed with H3_NO_ERROR");
+        } else {
+            error!("connection closed with error: {:?}", err);
+            return Err(err.into());
+        }
+    }
 ```
 
 You can find a full client example in [`examples/h3-client.rs`](./examples/h3-client.rs)


### PR DESCRIPTION
This pull request updates the documentation and examples for `msquic-async` and `h3-msquic-async` libraries to reflect significant changes in their APIs. The changes improve clarity, update dependencies, and refine error handling and configuration processes.

### Documentation Updates:

* Updated platform compatibility in `README.md` and `h3-msquic-async/README.md` to include Windows, Linux, and MacOS and revised dependency versions (`msquic-async` to `0.3.0` and `h3-msquic-async` to `0.2.0`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R110) [[2]](diffhunk://#diff-1ec9831ed64e748d3d178c23bf0eeff5842c1dd2f863b28a65e0ab522d5cf53bL10-R24)

### API Enhancements:

* Replaced `msquic::Registration::new(ptr::null())` with `msquic::Registration::new(&msquic::RegistrationConfig::default())` for better initialization. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R110) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R182)
* Updated `msquic::Configuration::new` to `msquic::Configuration::open` and streamlined credential loading for both server and client examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R110) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R182)

### Error Handling Improvements:

* Enhanced error handling in server and client examples, including more descriptive logging and handling specific error types like `StreamError` and `ConnectionError`. [[1]](diffhunk://#diff-1ec9831ed64e748d3d178c23bf0eeff5842c1dd2f863b28a65e0ab522d5cf53bL64-R65) [[2]](diffhunk://#diff-1ec9831ed64e748d3d178c23bf0eeff5842c1dd2f863b28a65e0ab522d5cf53bL123-R141)

### Example Refinements:

* Adjusted example code to use `BufferRef` instead of `Buffer` for ALPN and added new methods like `poll_finish_write` and `poll_shutdown` for better stream and connection management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R137) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R182)
* Refined the `h3-msquic-async` server example to include request resolution and improved error handling during request acceptance. [[1]](diffhunk://#diff-1ec9831ed64e748d3d178c23bf0eeff5842c1dd2f863b28a65e0ab522d5cf53bL42-R46) [[2]](diffhunk://#diff-1ec9831ed64e748d3d178c23bf0eeff5842c1dd2f863b28a65e0ab522d5cf53bL64-R65)…d improve example code