### PR TITLE
fix mismatched_lifetime_syntaxes

### DIFF
--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -61,7 +61,7 @@ impl Listener {
     }
 
     /// Accept a new connection.
-    pub fn accept(&self) -> Accept {
+    pub fn accept(&self) -> Accept<'_> {
         Accept(self)
     }
 
@@ -88,7 +88,7 @@ impl Listener {
     }
 
     /// Stop the listener.
-    pub fn stop(&self) -> Stop {
+    pub fn stop(&self) -> Stop<'_> {
         Stop(self)
     }
 


### PR DESCRIPTION
This pull request makes minor changes to the `Listener` implementation in `msquic-async/src/listener.rs` to improve type correctness by introducing lifetime parameters to the return types of the `accept` and `stop` methods.

Most important changes:

Type signature improvements:
* Added a lifetime parameter to the return type of the `accept` method, changing it from `Accept` to `Accept<'_>`.
* Added a lifetime parameter to the return type of the `stop` method, changing it from `Stop` to `Stop<'_>`.