### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,8 +16,8 @@ permissions: read-all
 env:
   RUST_BACKTRACE: 1
   toolchain_style: stable
-  toolchain_msrv: 1.83.0
-  toolchain_h3_msquic_msrv: 1.83.0
+  toolchain_msrv: 1.85.0
+  toolchain_h3_msquic_msrv: 1.85.0
   toolchain_doc: nightly-2024-12-11
   toolchain_lint: stable
   toolchain_fuzz: nightly-2024-12-11


### PR DESCRIPTION
This pull request updates the minimum supported Rust version (MSRV) in the CI workflow configuration to ensure compatibility with newer Rust features and dependencies.

Environment configuration update:

* [`.github/workflows/CI.yaml`](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L19-R20): Increased the `toolchain_msrv` and `toolchain_h3_msquic_msrv` environment variables from `1.83.0` to `1.85.0`.