### PR TITLE
output sskleylogfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,14 +131,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -168,12 +168,12 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c-types"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd721bd07cbda73f51e6a380ebfa4f02346f8b889e1ee92942350fefd16414"
+checksum = "5b2b477fbf7e6ad48fccc9a72fd2337cdf218a4a8e2119b467fc5fe0de75aaef"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "h3-msquic-async"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -471,6 +471,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -523,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -604,13 +610,14 @@ dependencies = [
 
 [[package]]
 name = "msquic-async"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argh",
  "bytes",
  "futures",
  "futures-io",
+ "hex",
  "libc",
  "msquic",
  "rangemap",
@@ -690,7 +697,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1171,12 +1178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1185,7 +1198,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -1194,14 +1216,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1211,10 +1250,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1223,10 +1274,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1235,10 +1298,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1247,7 +1322,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3.30"
 futures-io = "0.3.30"
 h3 = "0.0.8"
 h3-datagram = "0.0.2"
+hex = "0.4"
 http = "1"
 libc = "0.2.153"
 msquic = { version = "2.6.0-beta", path = "./msquic" }

--- a/h3-msquic-async/src/lib.rs
+++ b/h3-msquic-async/src/lib.rs
@@ -79,6 +79,7 @@ fn convert_connection_error(e: msquic_async::ConnectionError) -> ConnectionError
 
         error @ msquic_async::ConnectionError::ShutdownByLocal
         | error @ msquic_async::ConnectionError::ConnectionClosed
+        | error @ msquic_async::ConnectionError::SslKeyLogFileAlreadySet
         | error @ msquic_async::ConnectionError::OtherError(_) => {
             ConnectionErrorIncoming::Undefined(Arc::new(error))
         }

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -26,6 +26,7 @@ static = ["msquic/static"]
 [dependencies]
 bytes = { workspace = true }
 futures-io = { workspace = true }
+hex = { workspace = true }
 libc = { workspace = true }
 msquic = { workspace = true, features = ["preview-api"] }
 rangemap = { workspace = true }

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -1,4 +1,6 @@
 use msquic_async::msquic;
+use std::env;
+use std::fs::OpenOptions;
 use std::future::poll_fn;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::info;
@@ -32,6 +34,10 @@ async fn main() -> anyhow::Result<()> {
     configuration.load_credential(&cred_config)?;
 
     let conn = msquic_async::Connection::new(&registration)?;
+    if let Ok(sslkeylogfile) = env::var("SSLKEYLOGFILE") {
+        info!("SSLKEYLOGFILE is set: {}", sslkeylogfile);
+        conn.set_sslkeylog_file(OpenOptions::new().append(true).open(sslkeylogfile)?)?;
+    }
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 
     let mut stream = conn


### PR DESCRIPTION
This pull request adds support for SSL key logging to the `msquic-async` and `h3-msquic-async` libraries, allowing TLS secrets to be written to a file for debugging or analysis (e.g., Wireshark decryption). The implementation introduces a new method to set the SSL key log file, updates connection state management to handle TLS secrets, and adds error handling for duplicate key log file settings. The changes also update example clients to support the `SSLKEYLOGFILE` environment variable.

**SSL Key Logging Feature:**

* Added a new method `set_sslkeylog_file` to the `Connection` struct, enabling users to specify a file for logging TLS secrets. The method initializes TLS secrets and sets the appropriate msquic connection parameter.
* Updated connection state management to store and write TLS secrets to the specified file when the connection is established, supporting all relevant secret types and proper formatting for external tools.
* Extended `ConnectionError` with a new variant `SslKeyLogFileAlreadySet` to prevent setting the key log file multiple times. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R834-R835) [[2]](diffhunk://#diff-68089cbcd66392546be17655f340e20fe2c776678760ea13aff8419d3adebd10R82)

**Example Client Enhancements:**

* Modified `h3-client.rs` and `client.rs` examples to read the `SSLKEYLOGFILE` environment variable and use it to set the SSL key log file if provided. [[1]](diffhunk://#diff-5281411e79c196393526166634002eb5ac75d3f84b1ea158be6211911cb05c21R6-R7) [[2]](diffhunk://#diff-5281411e79c196393526166634002eb5ac75d3f84b1ea158be6211911cb05c21R40-R43) [[3]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4R2-R3) [[4]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4R37-R40)

**Dependency Updates:**

* Added the `hex` crate to both `Cargo.toml` files to support hex encoding of TLS secrets. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R16) [[2]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbR29)

**Internal Struct Updates:**

* Updated internal connection structs to store the SSL key log file and TLS secrets in connection state for proper management and access. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R446-R447) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R467-R468)

These changes make it easier to debug encrypted traffic and integrate with external analysis tools.