### PR TITLE
output sslkeylogfile on server

### DIFF
--- a/h3-msquic-async/examples/h3-client.rs
+++ b/h3-msquic-async/examples/h3-client.rs
@@ -39,7 +39,12 @@ async fn main() -> anyhow::Result<()> {
     let conn = msquic_async::Connection::new(&registration)?;
     if let Ok(sslkeylogfile) = env::var("SSLKEYLOGFILE") {
         info!("SSLKEYLOGFILE is set: {}", sslkeylogfile);
-        conn.set_sslkeylog_file(OpenOptions::new().append(true).open(sslkeylogfile)?)?;
+        conn.set_sslkeylog_file(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(sslkeylogfile)?,
+        )?;
     }
     conn.start(&configuration, "127.0.0.1", 8443).await?;
     let h3_conn = h3_msquic_async::Connection::new(conn);

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -36,7 +36,12 @@ async fn main() -> anyhow::Result<()> {
     let conn = msquic_async::Connection::new(&registration)?;
     if let Ok(sslkeylogfile) = env::var("SSLKEYLOGFILE") {
         info!("SSLKEYLOGFILE is set: {}", sslkeylogfile);
-        conn.set_sslkeylog_file(OpenOptions::new().append(true).open(sslkeylogfile)?)?;
+        conn.set_sslkeylog_file(
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(sslkeylogfile)?,
+        )?;
     }
     conn.start(&configuration, "127.0.0.1", 4567).await?;
 


### PR DESCRIPTION
This pull request adds support for setting an SSL key log file for QUIC connections and listeners, enabling easier debugging of TLS traffic. The main changes ensure that the SSL key log file is properly handled and propagated to new connections, and that the relevant secrets are initialized for each connection. Additionally, error handling and logging have been improved to provide better feedback when setting the key log file.

**SSL Key Log File Support**

* Added a `set_sslkeylog_file` method to the `Listener` struct, allowing users to specify an SSL key log file for all new connections. This method ensures the file is only set once and returns an error if called again. (`msquic-async/src/listener.rs`) [[1]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R130-R139) [[2]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R158) [[3]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R335-R336)
* Updated the connection creation logic so that new connections inherit the SSL key log file and initialize the TLS secrets structure when the log file is set. This involves changes to how `ConnectionInner` and `Connection` are constructed. (`msquic-async/src/connection.rs`, `msquic-async/src/listener.rs`) [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L28-R28) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L43-R53) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L451-R463) [[4]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L467-R480) [[5]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R198-L189)

**Example Usage and Logging Improvements**

* Updated example client and server code to support setting the SSL key log file via the `SSLKEYLOGFILE` environment variable, and improved logging to notify when the file is set. (`msquic-async/examples/client.rs`, `msquic-async/examples/server.rs`, `h3-msquic-async/examples/h3-client.rs`, `h3-msquic-async/examples/h3-server.rs`) [[1]](diffhunk://#diff-3c480b33e2dce69ed7776e48015217b51b5d9e33b5ca4a6c7a0c56b7dd4166f4L39-R44) [[2]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL1-R6) [[3]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fR114-R122) [[4]](diffhunk://#diff-5281411e79c196393526166634002eb5ac75d3f84b1ea158be6211911cb05c21L42-R47) [[5]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acR9-R10) [[6]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acR129-R137)
* Improved error and info logging for SSL key log file operations, including handling file cloning failures for new connections. (`msquic-async/src/listener.rs`) [[1]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L10-R10) [[2]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R198-L189)

These changes make it easier to debug QUIC/TLS connections by providing access to key material, and ensure robust handling and propagation of the SSL key log file throughout the connection lifecycle.