### PR TITLE
Bump msquic with minor modification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "ctor"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "deranged"

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -41,11 +41,10 @@ impl Connection {
     }
 
     pub(crate) fn from_raw(
-        handle: msquic::ffi::HQUIC,
+        msquic_conn: msquic::Connection,
         tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
         sslkeylog_file: Option<File>,
     ) -> Self {
-        let msquic_conn = unsafe { msquic::Connection::from_raw(handle) };
         let inner = Arc::new(ConnectionInner::new(
             ConnectionState::Connected,
             tls_secrets,

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -249,7 +249,7 @@ impl ListenerInner {
         };
         connection.set_configuration(&self.shared.configuration)?;
         let new_conn =
-            Connection::from_raw(unsafe { connection.as_raw() }, tls_secrets, sslkeylog_file);
+            Connection::from_raw(connection, tls_secrets, sslkeylog_file);
 
         exclusive.new_connections.push_back(new_conn);
         exclusive

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -191,7 +191,7 @@ impl ListenerInner {
     fn handle_event_new_connection(
         &self,
         _info: msquic::NewConnectionInfo<'_>,
-        connection: msquic::ConnectionRef,
+        connection: msquic::Connection,
     ) -> Result<(), msquic::Status> {
         trace!("Listener({:p}) New connection", self);
 

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -248,8 +248,7 @@ impl ListenerInner {
             (None, None)
         };
         connection.set_configuration(&self.shared.configuration)?;
-        let new_conn =
-            Connection::from_raw(connection, tls_secrets, sslkeylog_file);
+        let new_conn = Connection::from_raw(connection, tls_secrets, sslkeylog_file);
 
         exclusive.new_connections.push_back(new_conn);
         exclusive


### PR DESCRIPTION
This pull request updates the msquic submodule and refactors how new connections are handled in the `msquic-async` crate. The main focus is on simplifying the process of creating new `Connection` instances by passing `msquic::Connection` directly, rather than using raw handles.

**Submodule update:**

* Updated the `msquic` submodule to the latest commit.

**Connection handling refactor:**

* Changed the `Connection::from_raw` method to accept a `msquic::Connection` object directly instead of a raw handle, simplifying the API and improving type safety.
* Updated `ListenerInner::handle_event_new_connection` to accept a `msquic::Connection` instead of a reference, and adjusted the call to `Connection::from_raw` accordingly. [[1]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L194-R194) [[2]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L252-R252)