### PR TITLE
Add the new features such as use of SEERA MsQuic

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,9 +40,17 @@ jobs:
     name: Check Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
-          submodules: recursive
+          submodules: true
+      - name: Prepare Machine for msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: msquic
+      - name: Prepare Machine for seera-msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: seera-msquic
       - name: Install Rust ${{ env.toolchain_style }}
         uses: actions-rs/toolchain@v1
         with:
@@ -61,9 +69,17 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
-          submodules: recursive
+          submodules: true
+      - name: Prepare Machine for msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: msquic
+      - name: Prepare Machine for seera-msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: seera-msquic
       - name: Install Rust ${{ env.toolchain_lint }}
         uses: actions-rs/toolchain@v1
         with:
@@ -83,9 +99,17 @@ jobs:
     needs: [style]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
-          submodules: recursive
+          submodules: true
+      - name: Prepare Machine for msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: msquic
+      - name: Prepare Machine for seera-msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: seera-msquic
       - name: Install Rust ${{ env.toolchain_msrv }}
         uses: actions-rs/toolchain@v1
         with:
@@ -104,9 +128,17 @@ jobs:
     needs: [style]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
-          submodules: recursive
+          submodules: true
+      - name: Prepare Machine for msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: msquic
+      - name: Prepare Machine for seera-msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: seera-msquic
       - name: Install Rust ${{ env.toolchain_h3_msquic_msrv }}
         uses: actions-rs/toolchain@v1
         with:
@@ -127,23 +159,36 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        features: ["", "--features static"]
+        vec: [
+          { version: "msquic-latest", tls: "quictls", features: "" },
+          { version: "msquic-latest", tls: "quictls", features: "--features static" },
+          { version: "msquic-latest", tls: "quictls", features: "--features quictls" },
+          { version: "msquic-latest", tls: "quictls", features: "--features quictls,static" },
+          { version: "msquic-2-5", tls: "", features: "" },
+          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-static" },
+          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-quictls" },
+          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-quictls,msquic-2-5-static" },
+          { version: "msquic-seera", tls: "quictls", features: "" },
+          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-static" },
+          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-quictls" },
+          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-quictls,msquic-seera-static" },
+        ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           submodules: true
-      - name: Prepare Machine for Windows
-        if: runner.os == 'Windows'
-        run: scripts/prepare-machine.ps1 -Tls schannel -ForBuild -InstallTestCertificates
+      - name: Prepare Machine for msquic
+        if: matrix.vec.version == 'msquic-latest'
+        run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForBuild -InstallTestCertificates
         shell: pwsh
         working-directory: msquic
-      - name: Prepare Machine for Linux/MacOS
-        if: runner.os != 'Windows'
-        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild -InstallTestCertificates
+      - name: Prepare Machine for seera-msquic
+        if: matrix.vec.version == 'msquic-seera'
+        run: scripts/prepare-machine.ps1 -Tls ${{ matrix.vec.tls }} -ForBuild -InstallTestCertificates
         shell: pwsh
-        working-directory: msquic
+        working-directory: seera-msquic
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -163,16 +208,24 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -p msquic-async ${{ matrix.features }}
+          args: -p msquic-async ${{ matrix.vec.features }}
 
   doc:
     name: Build docs
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
-          submodules: recursive
+          submodules: true
+      - name: Prepare Machine for msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: msquic
+      - name: Prepare Machine for seera-msquic
+        run: scripts/prepare-machine.ps1 -Tls quictls -ForBuild
+        shell: pwsh
+        working-directory: seera-msquic
       - name: Install Rust ${{ env.toolchain_doc }}
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -153,7 +153,6 @@ jobs:
           args: -p h3-msquic-async
 
   test:
-    name: Test ${{ matrix.os }}
     needs: [style]
     strategy:
       fail-fast: false
@@ -164,14 +163,14 @@ jobs:
           { version: "msquic-latest", tls: "quictls", features: "--features static" },
           { version: "msquic-latest", tls: "quictls", features: "--features quictls" },
           { version: "msquic-latest", tls: "quictls", features: "--features quictls,static" },
-          { version: "msquic-2-5", tls: "", features: "" },
-          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-static" },
-          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-quictls" },
-          { version: "msquic-2-5", tls: "", features: "--features msquic-2-5-quictls,msquic-2-5-static" },
-          { version: "msquic-seera", tls: "quictls", features: "" },
-          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-static" },
-          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-quictls" },
-          { version: "msquic-seera", tls: "quictls", features: "--features msquic-seera-quictls,msquic-seera-static" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-static" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-quictls" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-quictls,msquic-2-5-static" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-static" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-quictls" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-quictls,msquic-seera-static" },
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -164,13 +164,13 @@ jobs:
           { version: "msquic-latest", tls: "quictls", features: "--features quictls" },
           { version: "msquic-latest", tls: "quictls", features: "--features quictls,static" },
           { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5" },
-          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-static" },
-          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-quictls" },
-          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5-quictls,msquic-2-5-static" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-static" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-quictls" },
+          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-quictls,msquic-2-5-static" },
           { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera" },
-          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-static" },
-          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-quictls" },
-          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera-quictls,msquic-seera-static" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-static" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-quictls" },
+          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-quictls,msquic-seera-static" },
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -211,7 +211,7 @@ jobs:
 
   doc:
     name: Build docs
-    needs: [test]
+    needs: [style]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "msquic"]
 	path = msquic
 	url = https://github.com/masa-koz/msquic.git
+[submodule "seera-msquic"]
+	path = seera-msquic
+	url = https://github.com/seera-networks/msquic.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,16 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "c-types"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdd721bd07cbda73f51e6a380ebfa4f02346f8b889e1ee92942350fefd16414"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "c-types"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2af3d25e10d58786fe80ccc21ae6574bca87e9a8c23fbdac63a8e62cfc37a7e"
@@ -228,13 +238,29 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro 0.0.6",
+ "dtor 0.0.6",
+]
+
+[[package]]
+name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "ctor-proc-macro 0.0.7",
+ "dtor 0.1.0",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "ctor-proc-macro"
@@ -253,12 +279,27 @@ dependencies = [
 
 [[package]]
 name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro 0.0.5",
+]
+
+[[package]]
+name = "dtor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.6",
 ]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "dtor-proc-macro"
@@ -268,9 +309,9 @@ checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -423,9 +464,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h3"
@@ -524,12 +565,12 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -597,13 +638,27 @@ dependencies = [
 
 [[package]]
 name = "msquic"
+version = "2.5.1-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea65fda5241a20053862abd4fc4e8ce92a08b5471a3ce26714d02fe42ebd6f6"
+dependencies = [
+ "bitflags",
+ "c-types 4.0.0",
+ "cmake",
+ "ctor 0.4.3",
+ "libc",
+ "socket2 0.5.8",
+]
+
+[[package]]
+name = "msquic"
 version = "2.6.0-beta"
 dependencies = [
  "bindgen",
  "bitflags",
- "c-types",
+ "c-types 6.0.0",
  "cmake",
- "ctor",
+ "ctor 0.6.3",
  "libc",
  "socket2 0.6.0",
 ]
@@ -619,9 +674,11 @@ dependencies = [
  "futures-io",
  "hex",
  "libc",
- "msquic",
+ "msquic 2.5.1-beta",
+ "msquic 2.6.0-beta",
  "rangemap",
  "schannel",
+ "seera-msquic",
  "tempfile",
  "test-log",
  "thiserror",
@@ -819,9 +876,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -850,6 +907,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seera-msquic"
+version = "2.6.0-beta"
+dependencies = [
+ "bindgen",
+ "bitflags",
+ "c-types 6.0.0",
+ "cmake",
+ "ctor 0.6.3",
+ "libc",
+ "socket2 0.6.0",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ hex = "0.4"
 http = "1"
 libc = "0.2.153"
 msquic = { version = "2.6.0-beta", path = "./msquic" }
-msquic-async = { version = "0.3.0", path = "./msquic-async" }
+msquic-v2-5 = { package = "msquic", version = "2.5.1-beta" }
+seera-msquic = { version = "2.6.0-beta", path = "./seera-msquic" }
+#seera-msquic = "2.6.0-beta2"
+msquic-async = { version = "0.3.0", path = "./msquic-async", default-features = false }
 rangemap = "1.5.1"
 schannel = "0.1.27"
 tempfile = "3.10.1"

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -19,11 +19,20 @@ include = [
 ]
 
 [features]
-default = []
-tracing = ["dep:tracing"]
-datagram = ["dep:h3-datagram"]
+default = ["msquic-latest"]
+msquic-latest = ["msquic-async/msquic-latest"]
+msquic-2-5 = ["msquic-async/msquic-2-5"]
+msquic-seera = ["msquic-async/msquic-seera"]
+
 quictls = ["msquic-async/quictls"]
 static = ["msquic-async/static"]
+msquic-2-5-quictls = ["msquic-async/msquic-2-5-quictls"]
+msquic-2-5-static = ["msquic-async/msquic-2-5-static"]
+msquic-seera-quictls = ["msquic-async/msquic-seera-quictls"]
+msquic-seera-static = ["msquic-async/msquic-seera-static"]
+
+tracing = ["dep:tracing"]
+datagram = ["dep:h3-datagram"]
 
 [dependencies]
 bytes = { workspace = true }

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -23,15 +23,14 @@ default = ["tokio", "msquic-latest"]
 
 msquic-latest = ["msquic"]
 msquic-2-5 = ["msquic-v2-5"]
-
-msquic-2-5-quictls = ["msquic-v2-5/quictls"]
-msquic-2-5-static = ["msquic-v2-5/static"]
+msquic-seera = ["seera-msquic"]
 
 quictls = ["msquic/quictls"]
 static = ["msquic/static"]
-
-seera-msquic-quictls = ["seera-msquic/quictls"]
-seera-msquic-static = ["seera-msquic/static"]
+msquic-2-5-quictls = ["msquic-v2-5/quictls"]
+msquic-2-5-static = ["msquic-v2-5/static"]
+msquic-seera-quictls = ["seera-msquic/quictls"]
+msquic-seera-static = ["seera-msquic/static"]
 
 [dependencies]
 bytes = { workspace = true }

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -19,16 +19,28 @@ include = [
 ]
 
 [features]
-default = ["tokio"]
+default = ["tokio", "msquic-latest"]
+
+msquic-latest = ["msquic"]
+msquic-2-5 = ["msquic-v2-5"]
+
+msquic-2-5-quictls = ["msquic-v2-5/quictls"]
+msquic-2-5-static = ["msquic-v2-5/static"]
+
 quictls = ["msquic/quictls"]
 static = ["msquic/static"]
+
+seera-msquic-quictls = ["seera-msquic/quictls"]
+seera-msquic-static = ["seera-msquic/static"]
 
 [dependencies]
 bytes = { workspace = true }
 futures-io = { workspace = true }
 hex = { workspace = true }
 libc = { workspace = true }
-msquic = { workspace = true, features = ["preview-api"] }
+msquic = { workspace = true, features = ["preview-api"], optional = true }
+msquic-v2-5 = { workspace = true, features = ["preview-api"], optional = true }
+seera-msquic = { workspace = true, features = [], optional = true }
 rangemap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util"], optional = true }

--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -1,5 +1,12 @@
 use crate::stream::StreamInstance;
 
+#[cfg(feature = "msquic-latest")]
+use msquic;
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+use seera_msquic as msquic;
+
 use std::io::IoSlice;
 use std::ops::Range;
 use std::slice;

--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -1,10 +1,8 @@
 use crate::stream::StreamInstance;
 
-#[cfg(feature = "msquic-latest")]
-use msquic;
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 use seera_msquic as msquic;
 
 use std::io::IoSlice;

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,11 +1,9 @@
 use crate::buffer::WriteBuffer;
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
 
-#[cfg(feature = "msquic-latest")]
-use msquic;
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 use seera_msquic as msquic;
 
 use std::collections::VecDeque;

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,6 +1,13 @@
 use crate::buffer::WriteBuffer;
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
 
+#[cfg(feature = "msquic-latest")]
+use msquic;
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+use seera_msquic as msquic;
+
 use std::collections::VecDeque;
 use std::fs::File;
 use std::future::Future;
@@ -41,10 +48,13 @@ impl Connection {
     }
 
     pub(crate) fn from_raw(
-        msquic_conn: msquic::Connection,
+        #[cfg(feature = "msquic-2-5")] handle: msquic::ffi::HQUIC,
+        #[cfg(not(feature = "msquic-2-5"))] msquic_conn: msquic::Connection,
         tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
         sslkeylog_file: Option<File>,
     ) -> Self {
+        #[cfg(feature = "msquic-2-5")]
+        let msquic_conn = unsafe { msquic::Connection::from_raw(handle) };
         let inner = Arc::new(ConnectionInner::new(
             ConnectionState::Connected,
             tls_secrets,

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -6,7 +6,12 @@ mod connection;
 mod listener;
 mod stream;
 
+#[cfg(feature = "msquic-latest")]
 pub use msquic;
+#[cfg(feature = "msquic-2-5")]
+pub use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+pub use seera_msquic as msquic;
 
 pub use buffer::StreamRecvBuffer;
 pub use connection::{

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -10,7 +10,7 @@ mod stream;
 pub use msquic;
 #[cfg(feature = "msquic-2-5")]
 pub use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 pub use seera_msquic as msquic;
 
 pub use buffer::StreamRecvBuffer;

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -1,5 +1,12 @@
 use crate::connection::Connection;
 
+#[cfg(feature = "msquic-latest")]
+use msquic;
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+use seera_msquic as msquic;
+
 use std::collections::VecDeque;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -191,7 +198,8 @@ impl ListenerInner {
     fn handle_event_new_connection(
         &self,
         _info: msquic::NewConnectionInfo<'_>,
-        connection: msquic::Connection,
+        #[cfg(feature = "msquic-2-5")] connection: msquic::ConnectionRef,
+        #[cfg(not(feature = "msquic-2-5"))] connection: msquic::Connection,
     ) -> Result<(), msquic::Status> {
         trace!("Listener({:p}) New connection", self);
 
@@ -248,6 +256,10 @@ impl ListenerInner {
             (None, None)
         };
         connection.set_configuration(&self.shared.configuration)?;
+        #[cfg(feature = "msquic-2-5")]
+        let new_conn =
+            Connection::from_raw(unsafe { connection.as_raw() }, tls_secrets, sslkeylog_file);
+        #[cfg(not(feature = "msquic-2-5"))]
         let new_conn = Connection::from_raw(connection, tls_secrets, sslkeylog_file);
 
         exclusive.new_connections.push_back(new_conn);

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -1,10 +1,8 @@
 use crate::connection::Connection;
 
-#[cfg(feature = "msquic-latest")]
-use msquic;
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 use seera_msquic as msquic;
 
 use std::collections::VecDeque;

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1,11 +1,9 @@
 use crate::buffer::{StreamRecvBuffer, WriteBuffer};
 use crate::connection::ConnectionError;
 
-#[cfg(feature = "msquic-latest")]
-use msquic;
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 use seera_msquic as msquic;
 
 use std::collections::VecDeque;

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1,6 +1,13 @@
 use crate::buffer::{StreamRecvBuffer, WriteBuffer};
 use crate::connection::ConnectionError;
 
+#[cfg(feature = "msquic-latest")]
+use msquic;
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+use seera_msquic as msquic;
+
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -2,6 +2,13 @@ use super::{
     Connection, ConnectionError, ConnectionStartError, ListenError, Listener, StreamRecvBuffer,
 };
 
+#[cfg(feature = "msquic-latest")]
+use msquic;
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "seera-msquic")]
+use seera_msquic as msquic;
+
 use std::future::poll_fn;
 use std::mem;
 use std::net::SocketAddr;

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -2,11 +2,9 @@ use super::{
     Connection, ConnectionError, ConnectionStartError, ListenError, Listener, StreamRecvBuffer,
 };
 
-#[cfg(feature = "msquic-latest")]
-use msquic;
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
-#[cfg(feature = "seera-msquic")]
+#[cfg(feature = "msquic-seera")]
 use seera_msquic as msquic;
 
 use std::future::poll_fn;


### PR DESCRIPTION
This pull request adds support for multiple versions and forks of the msquic library, specifically introducing compatibility with msquic 2.5 and the seera-msquic fork. It achieves this by updating Cargo features, dependencies, and the codebase to allow conditional compilation and selection of the appropriate msquic implementation. The CI workflow is also updated to test all supported variants across different operating systems and feature sets.

**Multi-version and multi-fork msquic support:**

- Added `msquic-v2-5` and `seera-msquic` as dependencies in `Cargo.toml`, and updated `msquic-async` to support conditional compilation for these libraries. The `default-features` is set to false for `msquic-async` to allow explicit feature selection. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L20-R23) [[2]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL22-R42)
- Introduced new features in both `msquic-async` and `h3-msquic-async` crates to enable building against different msquic versions/forks (`msquic-latest`, `msquic-2-5`, `msquic-seera`) and their respective TLS/static options. [[1]](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL22-R35) [[2]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL22-R42)
- Added the `seera-msquic` submodule and its configuration to `.gitmodules`. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4-R6) [[2]](diffhunk://#diff-c69b76b08f5300e7996135037f606838f264c6cc3a38751a58973eaf7f86f62aR1)

**Codebase adaptation for conditional msquic selection:**

- Updated Rust source files (`buffer.rs`, `connection.rs`, `listener.rs`, `stream.rs`, `tests.rs`, and `lib.rs`) to use the correct msquic crate via conditional imports and feature flags, ensuring the correct API is used for each msquic variant. [[1]](diffhunk://#diff-8d4dd05b3cdfae833ee5020318fe654cd734b9b1d1a7b3e2ab01fcc67db7461bR3-R7) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R4-R8) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3L44-R55) [[4]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R3-R7) [[5]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680L194-R200) [[6]](diffhunk://#diff-96f73fe96f54df2d23904d19f099f6639a87d6e816313d316f6aa6e9e71fd680R257-R260) [[7]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R4-R8) [[8]](diffhunk://#diff-a14c0379907b24a327d7f6260a4a95837a337a92c0c03003d5e506cba080ee5bR5-R9) [[9]](diffhunk://#diff-cb80d29055728d4a264c240be17bf6c1205ea923d387e0053affe37453467d45R9-R14)

**CI workflow enhancements:**

- The GitHub Actions workflow (`.github/workflows/CI.yaml`) is updated to:
  - Use a specific commit for `actions/checkout` and set submodules to `true` for all jobs.
  - Add preparation steps for both `msquic` and `seera-msquic` directories before building or testing.
  - Expand the test matrix to cover all combinations of msquic versions, TLS options, and feature sets, ensuring comprehensive CI coverage.
  - Adjust the test and doc jobs to use the new matrix and preparation logic. [[1]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L43-R53) [[2]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L64-R82) [[3]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L86-R112) [[4]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L107-R141) [[5]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L124-R190) [[6]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L166-R227)

These changes enable the project to build and test against multiple msquic implementations, improving flexibility and compatibility with upstream and forked versions.