### PR TITLE
Remove quictls feature

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -161,16 +161,10 @@ jobs:
         vec: [
           { version: "msquic-latest", tls: "quictls", features: "" },
           { version: "msquic-latest", tls: "quictls", features: "--features static" },
-          { version: "msquic-latest", tls: "quictls", features: "--features quictls" },
-          { version: "msquic-latest", tls: "quictls", features: "--features quictls,static" },
           { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5" },
           { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-static" },
-          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-quictls" },
-          { version: "msquic-2-5", tls: "", features: "--no-default-features --features tokio,msquic-2-5,msquic-2-5-quictls,msquic-2-5-static" },
           { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera" },
           { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-static" },
-          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-quictls" },
-          { version: "msquic-seera", tls: "quictls", features: "--no-default-features --features tokio,msquic-seera,msquic-seera-quictls,msquic-seera-static" },
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The [examples](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-asyn
         ),
     )?;
 
-    #[cfg(any(not(windows), feature = "quictls"))]
+    #[cfg(not(windows))]
     {
         use std::io::Write;
         use tempfile::NamedTempFile;
@@ -62,7 +62,7 @@ The [examples](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-asyn
         configuration.load_credential(&cred_config)?;
     }
 
-    #[cfg(all(windows, not(feature = "quictls")))]
+    #[cfg(windows)]
     {
         use schannel::cert_context::{CertContext, KeySpec};
         use schannel::cert_store::{CertAdd, Memory};

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -24,11 +24,8 @@ msquic-latest = ["msquic-async/msquic-latest"]
 msquic-2-5 = ["msquic-async/msquic-2-5"]
 msquic-seera = ["msquic-async/msquic-seera"]
 
-quictls = ["msquic-async/quictls"]
 static = ["msquic-async/static"]
-msquic-2-5-quictls = ["msquic-async/msquic-2-5-quictls"]
 msquic-2-5-static = ["msquic-async/msquic-2-5-static"]
-msquic-seera-quictls = ["msquic-async/msquic-seera-quictls"]
 msquic-seera-static = ["msquic-async/msquic-seera-static"]
 
 tracing = ["dep:tracing"]

--- a/h3-msquic-async/examples/h3-server.rs
+++ b/h3-msquic-async/examples/h3-server.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
         ),
     )?;
 
-    #[cfg(any(not(windows), feature = "quictls"))]
+    #[cfg(not(windows))]
     {
         use std::io::Write;
         use tempfile::NamedTempFile;
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         configuration.load_credential(&cred_config)?;
     }
 
-    #[cfg(all(windows, not(feature = "quictls")))]
+    #[cfg(windows)]
     {
         use schannel::cert_context::{CertContext, KeySpec};
         use schannel::cert_store::{CertAdd, Memory};

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -25,11 +25,8 @@ msquic-latest = ["msquic"]
 msquic-2-5 = ["msquic-v2-5"]
 msquic-seera = ["seera-msquic"]
 
-quictls = ["msquic/quictls"]
 static = ["msquic/static"]
-msquic-2-5-quictls = ["msquic-v2-5/quictls"]
 msquic-2-5-static = ["msquic-v2-5/static"]
-msquic-seera-quictls = ["seera-msquic/quictls"]
 msquic-seera-static = ["seera-msquic/static"]
 
 [dependencies]

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         ),
     )?;
 
-    #[cfg(any(not(windows), feature = "quictls"))]
+    #[cfg(not(windows))]
     {
         use std::io::Write;
         use tempfile::NamedTempFile;
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
         configuration.load_credential(&cred_config)?;
     }
 
-    #[cfg(all(windows, not(feature = "quictls")))]
+    #[cfg(windows)]
     {
         use schannel::cert_context::{CertContext, KeySpec};
         use schannel::cert_store::{CertAdd, Memory};

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1683,7 +1683,7 @@ async fn datagram_validation() {
     });
 }
 
-#[cfg(any(not(windows), feature = "quictls"))]
+#[cfg(not(windows))]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,
@@ -1716,7 +1716,7 @@ fn new_server(
     Ok(listener)
 }
 
-#[cfg(all(windows, not(feature = "quictls")))]
+#[cfg(windows)]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,


### PR DESCRIPTION
This pull request simplifies the platform-specific and feature-based conditional compilation logic throughout the codebase. It removes the use of the `quictls` feature flag for distinguishing between TLS implementations, now relying solely on platform checks (`windows` vs. non-windows). Additionally, it cleans up the feature lists in the relevant `Cargo.toml` files and CI matrix, removing all `quictls`-related feature combinations.

**Conditional compilation simplification:**

* Replaced all instances of `#[cfg(any(not(windows), feature = "quictls"))]` with `#[cfg(not(windows))]` and `#[cfg(all(windows, not(feature = "quictls")))]` with `#[cfg(windows)]` in example and test files (`msquic-async/examples/server.rs`, `h3-msquic-async/examples/h3-server.rs`, `msquic-async/src/tests.rs`, and `README.md`). This change removes the need for the `quictls` feature flag in platform-specific code paths. [[1]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL43-R43) [[2]](diffhunk://#diff-eb34a6f439b1e46cf08d01ef65bb6c28e0478a7a930ef8720ff227f5f27aca6fL68-R68) [[3]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acL54-R54) [[4]](diffhunk://#diff-c18846567f744b0ab41d5ce6c3a901ee9c172f1797610eb1b6616427782bb5acL79-R79) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R40) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65) [[7]](diffhunk://#diff-a14c0379907b24a327d7f6260a4a95837a337a92c0c03003d5e506cba080ee5bL1686-R1686) [[8]](diffhunk://#diff-a14c0379907b24a327d7f6260a4a95837a337a92c0c03003d5e506cba080ee5bL1719-R1719)

**Feature list and CI matrix cleanup:**

* Removed all `quictls`-related features from the feature lists in `Cargo.toml` files (`msquic-async/Cargo.toml`, `h3-msquic-async/Cargo.toml`). This includes `quictls`, `msquic-2-5-quictls`, and `msquic-seera-quictls`. [[1]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL28-L32) [[2]](diffhunk://#diff-ef229d09da0186e00276fbd31582d881aaa7a523d14d6919d9347eb24ad6504cL27-L31)
* Cleaned up the CI workflow matrix in `.github/workflows/CI.yaml` by removing jobs that build with `quictls` features.

These changes make the codebase easier to maintain and reduce confusion around feature flags and platform support.