### PR TITLE
Add new APIs using SEERA MsQuic features

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -384,7 +384,7 @@ impl Connection {
             .map_err(ConnectionError::OtherError)
     }
 
-    // Set whether to share the UDP binding.
+    /// Set whether to share the UDP binding.
     pub fn set_share_binding(&self, share: bool) -> Result<(), ConnectionError> {
         let share: u8 = if share { 1 } else { 0 };
         unsafe {
@@ -398,7 +398,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Add a new path to the connection.
+    /// Add a new path to the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn add_path(
         &self,
@@ -419,7 +419,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Activate a path for the connection.
+    /// Activate a path for the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn activate_path(
         &self,
@@ -440,7 +440,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Remove a path from the connection.
+    /// Remove a path from the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn remove_path(
         &self,
@@ -461,7 +461,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Add a bound address to the connection.
+    /// Add a bound address to the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn add_bound_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
         unsafe {
@@ -475,7 +475,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Add an observed address to the connection.
+    /// Add an observed address to the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn add_observed_addr(
         &self,
@@ -496,7 +496,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Remove a bound address from the connection.
+    /// Remove a bound address from the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn remove_bound_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
         unsafe {
@@ -510,7 +510,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Add a candidate address to the connection.
+    /// Add a candidate address to the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn add_candidate_addr(
         &self,
@@ -531,7 +531,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    // Remove a candidate address from the connection.
+    /// Remove a candidate address from the connection.
     #[cfg(feature = "msquic-seera")]
     pub fn remove_candidate_addr(
         &self,
@@ -983,8 +983,8 @@ impl ConnectionInner {
         local_address: &msquic::Addr,
         observed_address: &msquic::Addr,
     ) -> Result<(), msquic::Status> {
-        let local_address = local_address.as_socket().unwrap();
-        let observed_address = observed_address.as_socket().unwrap();
+        let local_address = local_address.as_socket().expect("socket addr");
+        let observed_address = observed_address.as_socket().expect("socket addr");
         trace!(
             "ConnectionInner({:p}) Notify observed address local_address:{} observed_address:{}",
             self,
@@ -1011,7 +1011,7 @@ impl ConnectionInner {
         address: &msquic::Addr,
         sequence_number: u64,
     ) -> Result<(), msquic::Status> {
-        let address = address.as_socket().unwrap();
+        let address = address.as_socket().expect("socket addr");
         trace!(
             "ConnectionInner({:p}) Notify remote address added address:{} sequence_number:{}",
             self,
@@ -1038,8 +1038,8 @@ impl ConnectionInner {
         local_address: &msquic::Addr,
         remote_address: &msquic::Addr,
     ) -> Result<(), msquic::Status> {
-        let local_address = local_address.as_socket().unwrap();
-        let remote_address = remote_address.as_socket().unwrap();
+        let local_address = local_address.as_socket().expect("socket addr");
+        let remote_address = remote_address.as_socket().expect("socket addr");
         trace!(
             "ConnectionInner({:p}) path validated local_address:{} remote_address:{}",
             self,
@@ -1171,17 +1171,17 @@ pub enum ConnectionEvent {
         local_address: SocketAddr,
         observed_address: SocketAddr,
     },
-    // A new remote address has been added.
+    /// A new remote address has been added.
     NotifyRemoteAddressAdded {
         address: SocketAddr,
         sequence_number: u64,
     },
-    // A path has been validated.
+    /// A path has been validated.
     PathValidated {
         local_address: SocketAddr,
         remote_address: SocketAddr,
     },
-    // remote address has been removed.
+    /// A remote address has been removed.
     NotifyRemoteAddressRemoved {
         sequence_number: u64,
     },

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -552,7 +552,7 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
-    /// Poll to recieve events on the connection.
+    /// Poll to receive events on the connection.
     pub fn poll_event(&self, cx: &mut Context<'_>) -> Poll<Result<ConnectionEvent, EventError>> {
         let mut exclusive = self.0.exclusive.lock().unwrap();
         match exclusive.state {

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1182,9 +1182,7 @@ pub enum ConnectionEvent {
         remote_address: SocketAddr,
     },
     /// A remote address has been removed.
-    NotifyRemoteAddressRemoved {
-        sequence_number: u64,
-    },
+    NotifyRemoteAddressRemoved { sequence_number: u64 },
 }
 
 /// Errors that can occur when managing a connection.

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -384,6 +384,201 @@ impl Connection {
             .map_err(ConnectionError::OtherError)
     }
 
+    // Set whether to share the UDP binding.
+    pub fn set_share_binding(&self, share: bool) -> Result<(), ConnectionError> {
+        let share: u8 = if share { 1 } else { 0 };
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_SHARE_UDP_BINDING,
+                std::mem::size_of::<u8>() as u32,
+                &share as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Add a new path to the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn add_path(
+        &self,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_ADD_PATH,
+                std::mem::size_of::<msquic::ffi::QUIC_PATH_PARAM>() as u32,
+                &msquic::ffi::QUIC_PATH_PARAM {
+                    LocalAddress: &mut msquic::Addr::from(local_addr) as *mut _ as *mut _,
+                    RemoteAddress: &mut msquic::Addr::from(remote_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Activate a path for the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn activate_path(
+        &self,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_ACTIVATE_PATH,
+                std::mem::size_of::<msquic::ffi::QUIC_PATH_PARAM>() as u32,
+                &msquic::ffi::QUIC_PATH_PARAM {
+                    LocalAddress: &mut msquic::Addr::from(local_addr) as *mut _ as *mut _,
+                    RemoteAddress: &mut msquic::Addr::from(remote_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Remove a path from the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn remove_path(
+        &self,
+        local_addr: SocketAddr,
+        remote_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_REMOVE_PATH,
+                std::mem::size_of::<msquic::ffi::QUIC_PATH_PARAM>() as u32,
+                &msquic::ffi::QUIC_PATH_PARAM {
+                    LocalAddress: &mut msquic::Addr::from(local_addr) as *mut _ as *mut _,
+                    RemoteAddress: &mut msquic::Addr::from(remote_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Add a bound address to the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn add_bound_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_ADD_BOUND_ADDRESS,
+                std::mem::size_of::<msquic::Addr>() as u32,
+                &msquic::Addr::from(addr) as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Add an observed address to the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn add_observed_addr(
+        &self,
+        addr: SocketAddr,
+        observed_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_ADD_OBSERVED_ADDRESS,
+                std::mem::size_of::<msquic::ffi::QUIC_ADD_OBSERVED_ADDRESS>() as u32,
+                &msquic::ffi::QUIC_ADD_OBSERVED_ADDRESS {
+                    LocalAddress: &mut msquic::Addr::from(addr) as *mut _ as *mut _,
+                    ObservedAddress: &mut msquic::Addr::from(observed_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Remove a bound address from the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn remove_bound_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_REMOVE_BOUND_ADDRESS,
+                std::mem::size_of::<msquic::Addr>() as u32,
+                &msquic::Addr::from(addr) as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Add a candidate address to the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn add_candidate_addr(
+        &self,
+        host_addr: SocketAddr,
+        observed_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_ADD_CANDIDATE_ADDRESS,
+                std::mem::size_of::<msquic::ffi::QUIC_CANDIDATE_ADDRESS>() as u32,
+                &msquic::ffi::QUIC_CANDIDATE_ADDRESS {
+                    HostAddress: &mut msquic::Addr::from(host_addr) as *mut _ as *mut _,
+                    ObservedAddress: &mut msquic::Addr::from(observed_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    // Remove a candidate address from the connection.
+    #[cfg(feature = "msquic-seera")]
+    pub fn remove_candidate_addr(
+        &self,
+        host_addr: SocketAddr,
+        observed_addr: SocketAddr,
+    ) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_REMOVE_CANDIDATE_ADDRESS,
+                std::mem::size_of::<msquic::ffi::QUIC_CANDIDATE_ADDRESS>() as u32,
+                &msquic::ffi::QUIC_CANDIDATE_ADDRESS {
+                    HostAddress: &mut msquic::Addr::from(host_addr) as *mut _ as *mut _,
+                    ObservedAddress: &mut msquic::Addr::from(observed_addr) as *mut _ as *mut _,
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    /// Poll to recieve events on the connection.
+    pub fn poll_event(&self, cx: &mut Context<'_>) -> Poll<Result<ConnectionEvent, EventError>> {
+        let mut exclusive = self.0.exclusive.lock().unwrap();
+        match exclusive.state {
+            ConnectionState::Open => {
+                return Poll::Ready(Err(EventError::ConnectionNotStarted));
+            }
+            ConnectionState::Connecting => {
+                exclusive.start_waiters.push(cx.waker().clone());
+                return Poll::Pending;
+            }
+            ConnectionState::Connected | ConnectionState::Shutdown => {}
+            ConnectionState::ShutdownComplete => {
+                return Poll::Ready(Err(EventError::ConnectionLost(
+                    exclusive.error.as_ref().expect("error").clone(),
+                )));
+            }
+        }
+
+        if exclusive.events.is_empty() {
+            exclusive.event_waiters.push(cx.waker().clone());
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(exclusive.events.pop_front().unwrap()))
+        }
+    }
+
     /// Set the SSL key log file for the connection.
     pub fn set_sslkeylog_file(&self, file: File) -> Result<(), ConnectionError> {
         let mut exclusive = self.0.exclusive.lock().unwrap();
@@ -458,6 +653,8 @@ struct ConnectionInnerExclusive {
     dgram_send_enabled: bool,
     dgram_max_send_length: u16,
     shutdown_waiters: Vec<Waker>,
+    events: VecDeque<ConnectionEvent>,
+    event_waiters: Vec<Waker>,
     sslkeylog_file: Option<File>,
     tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
 }
@@ -483,6 +680,8 @@ impl ConnectionInner {
                 dgram_send_enabled: false,
                 dgram_max_send_length: 0,
                 shutdown_waiters: Vec::new(),
+                events: VecDeque::new(),
+                event_waiters: Vec::new(),
                 sslkeylog_file,
                 tls_secrets,
             }),
@@ -653,6 +852,10 @@ impl ConnectionInner {
                 .shutdown_waiters
                 .drain(..)
                 .for_each(|waker| waker.wake());
+            exclusive
+                .event_waiters
+                .drain(..)
+                .for_each(|waker| waker.wake());
         }
         Ok(())
     }
@@ -774,6 +977,108 @@ impl ConnectionInner {
         Ok(())
     }
 
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_notify_observed_address(
+        &self,
+        local_address: &msquic::Addr,
+        observed_address: &msquic::Addr,
+    ) -> Result<(), msquic::Status> {
+        let local_address = local_address.as_socket().unwrap();
+        let observed_address = observed_address.as_socket().unwrap();
+        trace!(
+            "ConnectionInner({:p}) Notify observed address local_address:{} observed_address:{}",
+            self,
+            local_address,
+            observed_address
+        );
+        let mut exclusive = self.exclusive.lock().unwrap();
+        exclusive
+            .events
+            .push_back(ConnectionEvent::NotifyObservedAddress {
+                local_address,
+                observed_address,
+            });
+        exclusive
+            .event_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        Ok(())
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_notify_remote_address_added(
+        &self,
+        address: &msquic::Addr,
+        sequence_number: u64,
+    ) -> Result<(), msquic::Status> {
+        let address = address.as_socket().unwrap();
+        trace!(
+            "ConnectionInner({:p}) Notify remote address added address:{} sequence_number:{}",
+            self,
+            address,
+            sequence_number
+        );
+        let mut exclusive = self.exclusive.lock().unwrap();
+        exclusive
+            .events
+            .push_back(ConnectionEvent::NotifyRemoteAddressAdded {
+                address,
+                sequence_number,
+            });
+        exclusive
+            .event_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        Ok(())
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_path_validated(
+        &self,
+        local_address: &msquic::Addr,
+        remote_address: &msquic::Addr,
+    ) -> Result<(), msquic::Status> {
+        let local_address = local_address.as_socket().unwrap();
+        let remote_address = remote_address.as_socket().unwrap();
+        trace!(
+            "ConnectionInner({:p}) path validated local_address:{} remote_address:{}",
+            self,
+            local_address,
+            remote_address
+        );
+        let mut exclusive = self.exclusive.lock().unwrap();
+        exclusive.events.push_back(ConnectionEvent::PathValidated {
+            local_address,
+            remote_address,
+        });
+        exclusive
+            .event_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        Ok(())
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_notify_remote_address_removed(
+        &self,
+        sequence_number: u64,
+    ) -> Result<(), msquic::Status> {
+        trace!(
+            "ConnectionInner({:p}) Notify remote address removed sequence_number:{}",
+            self,
+            sequence_number
+        );
+        let mut exclusive = self.exclusive.lock().unwrap();
+        exclusive
+            .events
+            .push_back(ConnectionEvent::NotifyRemoteAddressRemoved { sequence_number });
+        exclusive
+            .event_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        Ok(())
+    }
+
     fn callback_handler_impl(
         &self,
         _connection: msquic::ConnectionRef,
@@ -817,6 +1122,25 @@ impl ConnectionInner {
                 client_context,
                 state,
             } => self.handle_event_datagram_send_state_changed(client_context, state),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::NotifyObservedAddress {
+                local_address,
+                observed_address,
+            } => self.handle_event_notify_observed_address(local_address, observed_address),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::NotifyRemoteAddressAdded {
+                address,
+                sequence_number,
+            } => self.handle_event_notify_remote_address_added(address, sequence_number),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::PathValidated {
+                local_address,
+                remote_address,
+            } => self.handle_event_path_validated(local_address, remote_address),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::NotifyRemoteAddressRemoved { sequence_number } => {
+                self.handle_event_notify_remote_address_removed(sequence_number)
+            }
             _ => {
                 trace!("ConnectionInner({:p}) Other callback", self);
                 Ok(())
@@ -837,6 +1161,30 @@ enum ConnectionState {
     Connected,
     Shutdown,
     ShutdownComplete,
+}
+
+/// Events that can occur on a connection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConnectionEvent {
+    /// A new observed address has been detected.
+    NotifyObservedAddress {
+        local_address: SocketAddr,
+        observed_address: SocketAddr,
+    },
+    // A new remote address has been added.
+    NotifyRemoteAddressAdded {
+        address: SocketAddr,
+        sequence_number: u64,
+    },
+    // A path has been validated.
+    PathValidated {
+        local_address: SocketAddr,
+        remote_address: SocketAddr,
+    },
+    // remote address has been removed.
+    NotifyRemoteAddressRemoved {
+        sequence_number: u64,
+    },
 }
 
 /// Errors that can occur when managing a connection.
@@ -894,6 +1242,17 @@ pub enum StartError {
 /// Errors that can occur when shutdowning a connection.
 #[derive(Debug, Error, Clone)]
 pub enum ShutdownError {
+    #[error("connection not started yet")]
+    ConnectionNotStarted,
+    #[error("connection lost")]
+    ConnectionLost(#[from] ConnectionError),
+    #[error("other error: status {0:?}")]
+    OtherError(msquic::Status),
+}
+
+/// Errors that can occur when receiving events on a connection.
+#[derive(Debug, Error, Clone)]
+pub enum EventError {
     #[error("connection not started yet")]
     ConnectionNotStarted,
     #[error("connection lost")]

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -15,9 +15,9 @@ pub use seera_msquic as msquic;
 
 pub use buffer::StreamRecvBuffer;
 pub use connection::{
-    AcceptInboundStream, AcceptInboundUniStream, Connection, ConnectionError, DgramReceiveError,
-    DgramSendError, OpenOutboundStream, ShutdownError as ConnectionShutdownError,
-    StartError as ConnectionStartError, ConnectionEvent, EventError,
+    AcceptInboundStream, AcceptInboundUniStream, Connection, ConnectionError, ConnectionEvent,
+    DgramReceiveError, DgramSendError, EventError, OpenOutboundStream,
+    ShutdownError as ConnectionShutdownError, StartError as ConnectionStartError,
 };
 pub use listener::{ListenError, Listener};
 pub use stream::{

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -17,7 +17,7 @@ pub use buffer::StreamRecvBuffer;
 pub use connection::{
     AcceptInboundStream, AcceptInboundUniStream, Connection, ConnectionError, DgramReceiveError,
     DgramSendError, OpenOutboundStream, ShutdownError as ConnectionShutdownError,
-    StartError as ConnectionStartError,
+    StartError as ConnectionStartError, ConnectionEvent, EventError,
 };
 pub use listener::{ListenError, Listener};
 pub use stream::{

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1925,7 +1925,7 @@ async fn test_poll_event_connection_lost_on_shutdown() {
     });
 }
 
-#[cfg(any(not(windows), feature = "quictls"))]
+#[cfg(not(windows))]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,
@@ -1958,7 +1958,7 @@ fn new_server(
     Ok(listener)
 }
 
-#[cfg(all(windows, not(feature = "quictls")))]
+#[cfg(windows)]
 fn new_server(
     registration: &msquic::Registration,
     settings: &msquic::Settings,

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1683,6 +1683,248 @@ async fn datagram_validation() {
     });
 }
 
+/// Test for ['Connection::poll_event()'] - events are queued correctly
+#[cfg(feature = "msquic-seera")]
+#[test(tokio::test)]
+async fn test_poll_event_queuing() {
+    use crate::EventError;
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let mut set = JoinSet::new();
+
+    // Server side - accept connection
+    set.spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        // Keep server alive for a bit
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    // Client side - connect and poll events
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+
+    set.spawn(async move {
+        // Try polling event before connection starts - should return ConnectionNotStarted
+        let result = poll_fn(|cx| conn.poll_event(cx)).await;
+        match result {
+            Err(EventError::ConnectionNotStarted) => {}
+            _ => panic!("Expected ConnectionNotStarted error before connection start"),
+        }
+
+        // Start the connection
+        conn.start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await
+        .unwrap();
+
+        // After connection, poll_event should either return events or be pending
+        // We don't expect specific events in this basic test, just verify it doesn't panic
+        // and handles the states correctly
+        let result = timeout(
+            Duration::from_millis(100),
+            poll_fn(|cx| conn.poll_event(cx)),
+        )
+        .await;
+        // Either timeout (Pending) or Ok with an event is acceptable
+        match result {
+            Err(_) => {}         // Timeout is fine - no events queued
+            Ok(Ok(_event)) => {} // Got an event - also fine
+            Ok(Err(e)) => panic!("Unexpected error: {:?}", e),
+        }
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
+/// Test for ['Connection::poll_event()'] - wakers are notified when events arrive
+#[cfg(feature = "msquic-seera")]
+#[test(tokio::test)]
+async fn test_poll_event_waker_notification() {
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let mut set = JoinSet::new();
+
+    // Server side
+    set.spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    // Client side
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+
+    set.spawn(async move {
+        conn.start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await
+        .unwrap();
+
+        // Wait a bit for connection to stabilize
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Add a path on client side to generate path events
+        let local_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let _ = conn.add_path(local_addr, server_addr);
+
+        // Try to poll for events with timeout - this tests that the waker works
+        // If there are no events, this will timeout (which is fine)
+        // If there are events, we successfully receive them (also fine)
+        let result = timeout(
+            Duration::from_millis(200),
+            poll_fn(|cx| conn.poll_event(cx)),
+        )
+        .await;
+
+        match result {
+            Err(_) => {}         // Timeout - no events, which is acceptable
+            Ok(Ok(_event)) => {} // Got an event - waker worked correctly
+            Ok(Err(e)) => panic!("Unexpected error: {:?}", e),
+        }
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
+/// Test for ['Connection::poll_event()'] - returns ConnectionLost on shutdown completion
+#[cfg(feature = "msquic-seera")]
+#[test(tokio::test)]
+async fn test_poll_event_connection_lost_on_shutdown() {
+    use crate::EventError;
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let mut set = JoinSet::new();
+
+    // Server side
+    set.spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    // Client side
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+
+    set.spawn(async move {
+        conn.start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await
+        .unwrap();
+
+        // Initiate shutdown
+        poll_fn(|cx| conn.poll_shutdown(cx, 0)).await.unwrap();
+
+        // Wait for shutdown to complete
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Now poll_event should return ConnectionLost error
+        let result = poll_fn(|cx| conn.poll_event(cx)).await;
+        match result {
+            Err(EventError::ConnectionLost(_)) => {
+                // This is what we expect after shutdown
+            }
+            other => panic!(
+                "Expected ConnectionLost error after shutdown, got: {:?}",
+                other
+            ),
+        }
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
 #[cfg(any(not(windows), feature = "quictls"))]
 fn new_server(
     registration: &msquic::Registration,


### PR DESCRIPTION
This pull request adds support for advanced connection management and event handling in the `msquic-async` library, primarily gated behind the `msquic-seera` feature. The most important changes include new methods for manipulating connection paths and addresses, a new event polling mechanism, and the introduction of custom connection events and errors. These updates make it possible to respond to dynamic network changes and receive notifications about connection state.

### Connection management enhancements

* Added new methods to the `Connection` struct for managing UDP binding, paths, bound addresses, observed addresses, and candidate addresses, including adding, activating, and removing them. These methods (except for managing UDP binding) are available when the `msquic-seera` feature is enabled.

### Event handling and notification

* Introduced a new event polling API: `Connection::poll_event`, which allows asynchronous polling for connection events, with proper handling for connection state transitions.
* Added internal storage for pending events (`events`) and event waiters (`event_waiters`) in `ConnectionInnerExclusive`, and ensured waiters are woken up when relevant events occur or connection state changes. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R656-R657) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R855-R858)
* Implemented handlers for new MsQuic connection events, such as observed address notifications, remote address additions/removals, and path validations, which push corresponding `ConnectionEvent` variants into the event queue. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R980-R1081) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R1125-R1143)

### API and type additions

* Defined a new `ConnectionEvent` enum to represent custom connection events, and an `EventError` enum for errors that can occur when polling for events. Both are now publicly exported from the crate. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R1166-R1189) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R1253-R1263) [[3]](diffhunk://#diff-cb80d29055728d4a264c240be17bf6c1205ea923d387e0053affe37453467d45L20-R20)

### Initialization updates

* Updated connection initialization to properly set up the new event queue and waiter structures.