### PR TITLE
add missing tokio feature

### DIFF
--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 h3 = { workspace = true }
 h3-datagram = { workspace = true, optional = true }
-msquic-async = { workspace = true }
+msquic-async = { workspace = true, features = ["tokio"] }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3-msquic-async"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic-Async based library for using h3"


### PR DESCRIPTION
This pull request updates the dependency configuration for `msquic-async` in the `h3-msquic-async` crate to explicitly enable the `tokio` feature. This change ensures that the `tokio` integration is included when building the project.

Dependency configuration update:

* Updated the `msquic-async` dependency in `h3-msquic-async/Cargo.toml` to enable the `tokio` feature, ensuring proper async runtime support.