### PR TITLE
fix recv datagram after shutdown

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -331,6 +331,7 @@ impl Connection {
                     .msquic_conn
                     .shutdown(msquic::ConnectionShutdownFlags::NONE, error_code);
                 exclusive.state = ConnectionState::Shutdown;
+                exclusive.error = Some(ConnectionError::ShutdownByLocal);
             }
             ConnectionState::Shutdown => {}
             ConnectionState::ShutdownComplete => {
@@ -360,6 +361,7 @@ impl Connection {
                     .msquic_conn
                     .shutdown(msquic::ConnectionShutdownFlags::NONE, error_code);
                 exclusive.state = ConnectionState::Shutdown;
+                exclusive.error = Some(ConnectionError::ShutdownByLocal);
             }
             _ => {}
         }
@@ -801,6 +803,10 @@ impl ConnectionInner {
             .inbound_stream_waiters
             .drain(..)
             .for_each(|waker| waker.wake());
+        exclusive
+            .recv_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
         Ok(())
     }
 
@@ -819,6 +825,10 @@ impl ConnectionInner {
             .for_each(|waker| waker.wake());
         exclusive
             .inbound_stream_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        exclusive
+            .recv_waiters
             .drain(..)
             .for_each(|waker| waker.wake());
         Ok(())
@@ -846,6 +856,10 @@ impl ConnectionInner {
                 .for_each(|waker| waker.wake());
             exclusive
                 .inbound_stream_waiters
+                .drain(..)
+                .for_each(|waker| waker.wake());
+            exclusive
+                .recv_waiters
                 .drain(..)
                 .for_each(|waker| waker.wake());
             exclusive

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1716,7 +1716,7 @@ async fn recv_datagram_after_peer_shutdown() {
         .await;
         match res {
             Err(_) => panic!("timeout waiting for datagram"),
-            Ok(Err(_)) => {},
+            Ok(Err(_)) => {}
             Ok(Ok(_)) => panic!("unexpected datagram received after shutdown"),
         }
 
@@ -1786,7 +1786,7 @@ async fn recv_datagram_after_local_shutdown() {
         .await;
         match res {
             Err(_) => panic!("timeout waiting for datagram"),
-            Ok(Err(_)) => {},
+            Ok(Err(_)) => {}
             Ok(Ok(_)) => panic!("unexpected datagram received after shutdown"),
         }
         server_tx.send(()).await.expect("send");

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -1683,6 +1683,145 @@ async fn datagram_validation() {
     });
 }
 
+#[test(tokio::test)]
+async fn recv_datagram_after_peer_shutdown() {
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new()
+            .set_IdleTimeoutMs(10000)
+            .set_DatagramReceiveEnabled(),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let res = listener.accept().await;
+        assert!(res.is_ok());
+        server_tx.send(()).await.expect("send");
+        let conn = res.expect("accept");
+        let res = timeout(
+            std::time::Duration::from_secs(10),
+            poll_fn(|cx| conn.poll_receive_datagram(cx)),
+        )
+        .await;
+        match res {
+            Err(_) => panic!("timeout waiting for datagram"),
+            Ok(Err(_)) => {},
+            Ok(Ok(_)) => panic!("unexpected datagram received after shutdown"),
+        }
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    let res = conn
+        .start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await;
+    assert!(res.is_ok());
+    client_rx.recv().await.expect("recv");
+    conn.shutdown(0).unwrap();
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
+#[test(tokio::test)]
+async fn recv_datagram_after_local_shutdown() {
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new()
+            .set_IdleTimeoutMs(10000)
+            .set_DatagramReceiveEnabled(),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let res = listener.accept().await;
+        assert!(res.is_ok());
+        let conn = res.expect("accept");
+        conn.shutdown(0).unwrap();
+        let res = timeout(
+            std::time::Duration::from_secs(10),
+            poll_fn(|cx| conn.poll_receive_datagram(cx)),
+        )
+        .await;
+        match res {
+            Err(_) => panic!("timeout waiting for datagram"),
+            Ok(Err(_)) => {},
+            Ok(Ok(_)) => panic!("unexpected datagram received after shutdown"),
+        }
+        server_tx.send(()).await.expect("send");
+
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    let _res = conn
+        .start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await;
+    client_rx.recv().await.expect("recv");
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
 /// Test for ['Connection::poll_event()'] - events are queued correctly
 #[cfg(feature = "msquic-seera")]
 #[test(tokio::test)]


### PR DESCRIPTION
This pull request improves the shutdown handling and datagram receiving logic in the `msquic-async` crate, particularly ensuring that all relevant wakers are notified during shutdown and adding comprehensive tests for datagram behavior after shutdown events.

**Shutdown and waker notification improvements:**

* Ensured that the `recv_waiters` wakers are drained and notified alongside `inbound_stream_waiters` during connection shutdown and shutdown completion, preventing potential hangs for tasks waiting to receive datagrams after shutdown. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R806-R809) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R830-R833) [[3]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R861-R864)
* Set the `error` field to `Some(ConnectionError::ShutdownByLocal)` when a local shutdown is initiated, improving error reporting for shutdown events. [[1]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R334) [[2]](diffhunk://#diff-229b69688ff5cbdfa31de046f541462d49579e8ed37bdcf2e0d97a277a690ef3R364)

**Testing improvements:**

* Added two new async tests, `recv_datagram_after_peer_shutdown` and `recv_datagram_after_local_shutdown`, to verify that no datagrams are received after either peer or local shutdown, and that the connection handles these scenarios correctly.