### PR TITLE
bump msquic-async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "ctor-proc-macro 0.0.13",
+ "dtor 0.8.1",
+ "link-section",
+]
+
+[[package]]
 name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +278,12 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "deranged"
@@ -296,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+dependencies = [
+ "dtor-proc-macro 0.0.13",
+]
+
+[[package]]
 name = "dtor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +332,12 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "either"
@@ -495,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "h3-msquic-async"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argh",
@@ -572,6 +604,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b685d66585d646efe09fec763d796c291049c8b6bf84e04954bffc8748341f0d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -665,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "msquic-async"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "argh",
@@ -910,13 +948,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seera-msquic"
-version = "2.6.0-beta2"
+version = "2.6.0-beta3"
 dependencies = [
  "bindgen",
  "bitflags",
  "c-types 6.0.0",
  "cmake",
- "ctor 0.6.3",
+ "ctor 0.10.1",
  "libc",
  "socket2 0.6.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2.153"
 msquic = { version = "2.6.0-beta", path = "./msquic" }
 msquic-v2-5 = { package = "msquic", version = "2.5.1-beta" }
 seera-msquic = { version = "2.6.0-beta2", path = "./seera-msquic" }
-msquic-async = { version = "0.4.0", path = "./msquic-async", default-features = false }
+msquic-async = { version = "0.4.1", path = "./msquic-async", default-features = false }
 rangemap = "1.5.1"
 schannel = "0.1.27"
 tempfile = "3.10.1"

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic-async"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic based quic library that supports async operation"


### PR DESCRIPTION
This pull request updates the `msquic-async` dependency to version 0.4.1 throughout the project to ensure consistency and take advantage of any improvements or fixes in the new version.

Dependency version update:

* Updated the `msquic-async` dependency from version 0.4.0 to 0.4.1 in both the main `Cargo.toml` and the `msquic-async/Cargo.toml` files. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L22-R22) [[2]](diffhunk://#diff-1283c66bcd7696bda6564b294aa5ba9f09c704f27678e5f7c79c7b5d789c49fbL3-R3)