### PR TITLE
Fix tokio's poll_read

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -197,6 +197,9 @@ jobs:
       - name: Install NASM
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b
+      - name: Set up MSVC dev environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
       - uses: Swatinem/rust-cache@v2
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -190,6 +190,15 @@ impl Stream {
         self.0.poll_read(cx, buf)
     }
 
+    /// Poll to read from the stream into the provided ReadBuf.
+    pub fn poll_read_buf(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), ReadError>> {
+        self.0.poll_read_buf(cx, buf)
+    }
+
     /// Poll to read the next segment of data.
     pub fn poll_read_chunk(
         &self,
@@ -294,6 +303,15 @@ impl ReadStream {
         buf: &mut [u8],
     ) -> Poll<Result<usize, ReadError>> {
         self.0.poll_read(cx, buf)
+    }
+
+    /// Poll to read from the stream into the provided ReadBuf.
+    pub fn poll_read_buf(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), ReadError>> {
+        self.0.poll_read_buf(cx, buf)
     }
 
     /// Poll to read the next segment of data.
@@ -427,8 +445,8 @@ impl StreamInstance {
         buf: &mut [u8],
     ) -> Poll<Result<usize, ReadError>> {
         self.poll_read_generic(cx, |recv_buffers, read_complete_buffers| {
-            let mut read = 0;
             let mut fin = false;
+            let mut read = 0;
             loop {
                 if read == buf.len() {
                     return ReadStatus::Readable(read);
@@ -457,6 +475,47 @@ impl StreamInstance {
             }
         })
         .map(|res| res.map(|x| x.unwrap_or(0)))
+    }
+
+    fn poll_read_buf(
+        self: &Arc<Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), ReadError>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        self.poll_read_generic(cx, |recv_buffers, read_complete_buffers| {
+            let mut fin = false;
+            let mut read = false;
+            loop {
+                if buf.remaining() == 0 {
+                    return ReadStatus::Readable(());
+                }
+
+                match recv_buffers
+                    .front_mut()
+                    .and_then(|x| x.get_bytes_upto_size(buf.remaining()))
+                {
+                    Some(slice) => {
+                        buf.put_slice(slice);
+                        read = true;
+                    }
+                    None => {
+                        if let Some(mut recv_buffer) = recv_buffers.pop_front() {
+                            recv_buffer.set_stream(self.clone());
+                            fin = recv_buffer.fin();
+                            read_complete_buffers.push(recv_buffer);
+                            continue;
+                        } else {
+                            return (if read { Some(()) } else { None }, fin).into();
+                        }
+                    }
+                }
+            }
+        })
+        .map(|res| res.map(|_| ()))
     }
 
     fn poll_read_chunk(
@@ -1364,8 +1423,7 @@ impl tokio::io::AsyncRead for Stream {
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        let len = ready!(Self::poll_read(self.get_mut(), cx, buf.initialized_mut()))?;
-        buf.set_filled(len);
+        ready!(Self::poll_read_buf(self.get_mut(), cx, buf))?;
         Poll::Ready(Ok(()))
     }
 }
@@ -1398,8 +1456,7 @@ impl tokio::io::AsyncRead for ReadStream {
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        let len = ready!(Self::poll_read(self.get_mut(), cx, buf.initialized_mut()))?;
-        buf.set_filled(len);
+        ready!(Self::poll_read_buf(self.get_mut(), cx, buf))?;
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
This pull request adds a new `poll_read_buf` method to the `Stream`, `ReadStream`, and `StreamInstance` types in `msquic-async/src/stream.rs`, improving integration with Tokio's `ReadBuf` and simplifying the implementation of the `AsyncRead` trait. The main changes are grouped by new API additions and internal refactoring.

### New API Additions

* Added a `poll_read_buf` method to the `Stream` and `ReadStream` structs, allowing efficient reading into a `tokio::io::ReadBuf`. This provides a more idiomatic and potentially more performant way to read data using Tokio's async I/O patterns. [[1]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R193-R201) [[2]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545R308-R316)
* Implemented the underlying `poll_read_buf` logic in `StreamInstance`, handling buffer management and reading data into the provided `ReadBuf`.

### Internal Refactoring

* Updated the `AsyncRead` trait implementations for both `Stream` and `ReadStream` to use the new `poll_read_buf` method, simplifying the code and improving consistency with Tokio's expectations. [[1]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L1367-R1426) [[2]](diffhunk://#diff-e3866dd32b0d2ec8f7e59968907b68db42533594b2da73b87ef00be97fe25545L1401-R1459)
* Minor cleanup in `poll_read` logic for `StreamInstance` for clarity.