### PR TITLE
Remove install of perl

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -189,11 +189,6 @@ jobs:
       - name: Pin macOS deployment target
         if: runner.os == 'macOS'
         run: echo "MACOSX_DEPLOYMENT_TARGET=14.5" >> "$GITHUB_ENV"
-      - name: Install Perl
-        if: runner.os == 'Windows'
-        uses: shogo82148/actions-setup-perl@98dfedee230bcf1ee68d5b021931fc8d63f2016e
-        with:
-          perl-version: '5.34'
       - name: Install NASM
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by removing the Perl installation step for Windows runners. This streamlines the setup process and eliminates an unnecessary dependency.

* Removed the step that installs Perl (`shogo82148/actions-setup-perl`) for Windows in the `.github/workflows/CI.yaml` workflow.