### PR TITLE
Sync with the latest msquic, which refers to masa-koz's fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "msquic"]
 	path = msquic
-	url = https://github.com/microsoft/msquic.git
+	url = https://github.com/masa-koz/msquic.git
 [submodule "seera-msquic"]
 	path = seera-msquic
 	url = https://github.com/seera-networks/msquic.git


### PR DESCRIPTION
This pull request updates the `msquic` submodule to point to a new repository and a more recent commit. These changes ensure that the project uses the intended fork and the latest code from that source.

Submodule updates:

* Changed the `msquic` submodule URL in `.gitmodules` to point to `https://github.com/masa-koz/msquic.git` instead of the original Microsoft repository.
* Updated the `msquic` submodule to reference commit `b63246910d944fc7a18c2a3a8b0153b79afecfdb`, pulling in the latest changes from the new repository.