### PR TITLE
Add new features for openssl external link

### DIFF
--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [features]
 default = ["msquic-latest"]
+
 msquic-latest = ["msquic-async/msquic-latest"]
 msquic-2-5 = ["msquic-async/msquic-2-5"]
 msquic-seera = ["msquic-async/msquic-seera"]
@@ -27,6 +28,9 @@ msquic-seera = ["msquic-async/msquic-seera"]
 static = ["msquic-async/static"]
 msquic-2-5-static = ["msquic-async/msquic-2-5-static"]
 msquic-seera-static = ["msquic-async/msquic-seera-static"]
+
+openssl-external = ["msquic-async/openssl-external"]
+msquic-seera-openssl-external = ["msquic-async/msquic-seera-openssl-external"]
 
 tracing = ["dep:tracing"]
 datagram = ["dep:h3-datagram"]

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -29,6 +29,9 @@ static = ["msquic/static"]
 msquic-2-5-static = ["msquic-v2-5/static"]
 msquic-seera-static = ["seera-msquic/static"]
 
+openssl-external = ["msquic/openssl_external"]
+msquic-seera-openssl-external = ["seera-msquic/openssl_external"]
+
 [dependencies]
 bytes = { workspace = true }
 futures-io = { workspace = true }


### PR DESCRIPTION
This pull request adds new feature flags to both the `h3-msquic-async` and `msquic-async` crates to support external OpenSSL integration, as well as corresponding feature flags for Seera builds. These changes make it easier to opt into using external OpenSSL in different build configurations.

New feature flags for external OpenSSL support:

* Added `openssl-external` and `msquic-seera-openssl-external` feature flags to `h3-msquic-async/Cargo.toml`, enabling external OpenSSL integration for both the main and Seera builds.
* Added `openssl-external` and `msquic-seera-openssl-external` feature flags to `msquic-async/Cargo.toml`, mapping to the relevant dependencies for external OpenSSL support.

Other minor changes:

* Minor formatting adjustment in the feature list of `h3-msquic-async/Cargo.toml` for consistency.