### PR TITLE
Fix security issues (UAF, FFI panic, buffer leak, cert validation)

### DIFF
--- a/h3-msquic-async/examples/h3-client.rs
+++ b/h3-msquic-async/examples/h3-client.rs
@@ -32,9 +32,35 @@ async fn main() -> anyhow::Result<()> {
                 .set_StreamMultiReceiveEnabled(),
         ),
     )?;
-    let cred_config = msquic::CredentialConfig::new_client()
-        .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
-    configuration.load_credential(&cred_config)?;
+    // Validate the server certificate by default. The example server uses a
+    // self-signed certificate (`cert.pem`), so we pin that same certificate as
+    // the trusted CA.
+    //
+    // Setting `H3_CLIENT_INSECURE=1` skips validation via
+    // `NO_CERTIFICATE_VALIDATION`. This is for local testing ONLY: it disables
+    // authentication of the server and defeats TLS, so it must never be used in
+    // production or copied into real client code.
+    if env::var("H3_CLIENT_INSECURE").is_ok() {
+        info!("H3_CLIENT_INSECURE is set: skipping certificate validation (test only)");
+        let cred_config = msquic::CredentialConfig::new_client()
+            .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
+        configuration.load_credential(&cred_config)?;
+    } else {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let ca_cert = include_bytes!("cert.pem");
+        let mut ca_cert_file = NamedTempFile::new()?;
+        ca_cert_file.write_all(ca_cert)?;
+        let ca_cert_path = ca_cert_file.into_temp_path();
+        let ca_cert_path_str = ca_cert_path.to_string_lossy().into_owned();
+
+        let cred_config =
+            msquic::CredentialConfig::new_client().set_ca_certificate_file(ca_cert_path_str);
+        configuration.load_credential(&cred_config)?;
+        // `ca_cert_path` is dropped (and the temp file removed) only here, after
+        // `load_credential` has read it.
+    }
 
     let conn = msquic_async::Connection::new(&registration)?;
     if let Ok(sslkeylogfile) = env::var("SSLKEYLOGFILE") {

--- a/msquic-async/src/buffer.rs
+++ b/msquic-async/src/buffer.rs
@@ -135,6 +135,10 @@ impl StreamRecvBuffer {
     }
 }
 
+// SAFETY: `StreamRecvBuffer` holds raw pointers into MsQuic-owned receive
+// memory. That memory stays valid until the buffer is completed (which happens
+// on drop, via the `Arc<StreamInstance>` the buffer keeps alive), so the
+// pointers are sound to move and share across threads.
 unsafe impl Sync for StreamRecvBuffer {}
 unsafe impl Send for StreamRecvBuffer {}
 
@@ -205,6 +209,11 @@ struct WriteBufferInner {
     zerocopy: Vec<Bytes>,
     buffers: Vec<msquic::BufferRef>,
 }
+// SAFETY: `WriteBufferInner` only owns `Vec`/`Bytes` data plus `BufferRef`s that
+// point back into that same owned data. Ownership is transferred to MsQuic as a
+// raw pointer for the duration of a send and handed back in the completion
+// callback, so the buffer is only ever accessed from one place at a time and is
+// safe to move and share across threads.
 unsafe impl Sync for WriteBufferInner {}
 unsafe impl Send for WriteBufferInner {}
 

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,5 +1,6 @@
 use crate::buffer::WriteBuffer;
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
+use crate::sync::LockPoisonTolerant;
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -12,6 +13,7 @@ use std::future::Future;
 use std::io::{Seek, SeekFrom, Write};
 use std::net::SocketAddr;
 use std::ops::Deref;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
@@ -20,7 +22,7 @@ use bytes::Bytes;
 use libc::c_void;
 use msquic::ffi::QUIC_TLS_SECRETS__bindgen_ty_1;
 use thiserror::Error;
-use tracing::{info, trace};
+use tracing::{error, info, trace};
 
 #[derive(Clone)]
 pub struct Connection(Arc<ConnectionInstance>);
@@ -94,7 +96,7 @@ impl Connection {
         host: &str,
         port: u16,
     ) -> Poll<Result<(), StartError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 self.0
@@ -139,7 +141,7 @@ impl Connection {
         &self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Stream, StreamStartError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));
@@ -173,7 +175,7 @@ impl Connection {
         &self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<ReadStream, StreamStartError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));
@@ -204,7 +206,7 @@ impl Connection {
         &self,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Bytes, DgramReceiveError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(DgramReceiveError::ConnectionNotStarted));
@@ -235,7 +237,7 @@ impl Connection {
         cx: &mut Context<'_>,
         buf: &Bytes,
     ) -> Poll<Result<(), DgramSendError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(DgramSendError::ConnectionNotStarted));
@@ -252,26 +254,19 @@ impl Connection {
             }
         }
 
-        let mut write_buf = exclusive.write_pool.pop().unwrap_or(WriteBuffer::new());
-        let _ = write_buf.put_zerocopy(buf);
-        let buffers = unsafe {
-            let (data, len) = write_buf.get_buffers();
-            std::slice::from_raw_parts(data, len)
-        };
-        let res = unsafe {
-            self.0.msquic_conn.datagram_send(
-                buffers,
-                msquic::SendFlags::NONE,
-                write_buf.into_raw() as *const _,
-            )
+        if !exclusive.dgram_send_enabled {
+            return Poll::Ready(Err(DgramSendError::Denied));
         }
-        .map_err(DgramSendError::OtherError);
-        Poll::Ready(res)
+        if buf.len() > exclusive.dgram_max_send_length as usize {
+            return Poll::Ready(Err(DgramSendError::TooBig));
+        }
+
+        Poll::Ready(exclusive.send_datagram(&self.0.msquic_conn, buf))
     }
 
     /// Send a datagram.
     pub fn send_datagram(&self, buf: &Bytes) -> Result<(), DgramSendError> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Err(DgramSendError::ConnectionNotStarted);
@@ -294,21 +289,7 @@ impl Connection {
             return Err(DgramSendError::TooBig);
         }
 
-        let mut write_buf = exclusive.write_pool.pop().unwrap_or(WriteBuffer::new());
-        let _ = write_buf.put_zerocopy(buf);
-        let buffers = unsafe {
-            let (data, len) = write_buf.get_buffers();
-            std::slice::from_raw_parts(data, len)
-        };
-        unsafe {
-            self.0.msquic_conn.datagram_send(
-                buffers,
-                msquic::SendFlags::NONE,
-                write_buf.into_raw() as *const _,
-            )
-        }
-        .map_err(DgramSendError::OtherError)?;
-        Ok(())
+        exclusive.send_datagram(&self.0.msquic_conn, buf)
     }
 
     /// Poll to shutdown the connection.
@@ -317,7 +298,7 @@ impl Connection {
         cx: &mut Context<'_>,
         error_code: u64,
     ) -> Poll<Result<(), ShutdownError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(ShutdownError::ConnectionNotStarted));
@@ -351,7 +332,7 @@ impl Connection {
 
     /// Shutdown the connection.
     pub fn shutdown(&self, error_code: u64) -> Result<(), ShutdownError> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open | ConnectionState::Connecting => {
                 return Err(ShutdownError::ConnectionNotStarted);
@@ -556,7 +537,7 @@ impl Connection {
 
     /// Poll to receive events on the connection.
     pub fn poll_event(&self, cx: &mut Context<'_>) -> Poll<Result<ConnectionEvent, EventError>> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(EventError::ConnectionNotStarted));
@@ -583,7 +564,7 @@ impl Connection {
 
     /// Set the SSL key log file for the connection.
     pub fn set_sslkeylog_file(&self, file: File) -> Result<(), ConnectionError> {
-        let mut exclusive = self.0.exclusive.lock().unwrap();
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
         if exclusive.sslkeylog_file.is_some() {
             return Err(ConnectionError::SslKeyLogFileAlreadySet);
         }
@@ -661,6 +642,43 @@ struct ConnectionInnerExclusive {
     tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
 }
 
+impl ConnectionInnerExclusive {
+    /// Sends `buf` as a datagram, reclaiming the send buffer if MsQuic rejects
+    /// the send.
+    ///
+    /// Ownership of the buffer is handed to MsQuic as a raw pointer and returned
+    /// via the DatagramSendStateChanged callback. On an error MsQuic never took
+    /// it and no callback fires, so it must be reclaimed here to avoid leaking
+    /// the buffer (and the `Bytes` it holds) on every failed send — otherwise a
+    /// peer that forces sends to fail could drive unbounded memory growth.
+    fn send_datagram(
+        &mut self,
+        msquic_conn: &msquic::Connection,
+        buf: &Bytes,
+    ) -> Result<(), DgramSendError> {
+        let mut write_buf = self.write_pool.pop().unwrap_or_else(WriteBuffer::new);
+        let _ = write_buf.put_zerocopy(buf);
+        let buffers = unsafe {
+            let (data, len) = write_buf.get_buffers();
+            std::slice::from_raw_parts(data, len)
+        };
+        let raw = write_buf.into_raw();
+        match unsafe {
+            msquic_conn.datagram_send(buffers, msquic::SendFlags::NONE, raw as *const _)
+        }
+        .map_err(DgramSendError::OtherError)
+        {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let mut write_buf = unsafe { WriteBuffer::from_raw(raw) };
+                write_buf.reset();
+                self.write_pool.push(write_buf);
+                Err(e)
+            }
+        }
+    }
+}
+
 impl ConnectionInner {
     fn new(
         state: ConnectionState,
@@ -697,7 +715,7 @@ impl ConnectionInner {
     ) -> Result<(), msquic::Status> {
         trace!("ConnectionInner({:p}) Connected", self);
 
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         match (
             exclusive.tls_secrets.take(),
             exclusive.sslkeylog_file.take(),
@@ -710,6 +728,12 @@ impl ConnectionInner {
                     String::new()
                 };
 
+                // `SecretLength` is supplied by MsQuic; clamp it to the actual
+                // array capacity so a bogus value can never cause an
+                // out-of-bounds slice panic.
+                let secret_len = (tls_secrets.SecretLength as usize)
+                    .min(msquic::ffi::QUIC_TLS_SECRETS_MAX_SECRET_LEN as usize);
+
                 let _ = file.seek(SeekFrom::End(0));
 
                 if tls_secrets.IsSet.ClientEarlyTrafficSecret() != 0 {
@@ -717,10 +741,7 @@ impl ConnectionInner {
                         file,
                         "CLIENT_EARLY_TRAFFIC_SECRET {} {}",
                         client_random,
-                        hex::encode(
-                            &tls_secrets.ClientEarlyTrafficSecret
-                                [0..tls_secrets.SecretLength as usize]
-                        )
+                        hex::encode(&tls_secrets.ClientEarlyTrafficSecret[0..secret_len])
                     );
                 }
 
@@ -729,10 +750,7 @@ impl ConnectionInner {
                         file,
                         "CLIENT_HANDSHAKE_TRAFFIC_SECRET {} {}",
                         client_random,
-                        hex::encode(
-                            &tls_secrets.ClientHandshakeTrafficSecret
-                                [0..tls_secrets.SecretLength as usize]
-                        )
+                        hex::encode(&tls_secrets.ClientHandshakeTrafficSecret[0..secret_len])
                     );
                 }
 
@@ -741,10 +759,7 @@ impl ConnectionInner {
                         file,
                         "SERVER_HANDSHAKE_TRAFFIC_SECRET {} {}",
                         client_random,
-                        hex::encode(
-                            &tls_secrets.ServerHandshakeTrafficSecret
-                                [0..tls_secrets.SecretLength as usize]
-                        )
+                        hex::encode(&tls_secrets.ServerHandshakeTrafficSecret[0..secret_len])
                     );
                 }
 
@@ -753,9 +768,7 @@ impl ConnectionInner {
                         file,
                         "CLIENT_TRAFFIC_SECRET_0 {} {}",
                         client_random,
-                        hex::encode(
-                            &tls_secrets.ClientTrafficSecret0[0..tls_secrets.SecretLength as usize]
-                        )
+                        hex::encode(&tls_secrets.ClientTrafficSecret0[0..secret_len])
                     );
                 }
 
@@ -764,9 +777,7 @@ impl ConnectionInner {
                         file,
                         "SERVER_TRAFFIC_SECRET_0 {} {}",
                         client_random,
-                        hex::encode(
-                            &tls_secrets.ServerTrafficSecret0[0..tls_secrets.SecretLength as usize]
-                        )
+                        hex::encode(&tls_secrets.ServerTrafficSecret0[0..secret_len])
                     );
                 }
                 exclusive.tls_secrets = Some(tls_secrets);
@@ -792,7 +803,7 @@ impl ConnectionInner {
             status
         );
 
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.state = ConnectionState::Shutdown;
         exclusive.error = Some(ConnectionError::ShutdownByTransport(status, error_code));
         exclusive
@@ -816,7 +827,7 @@ impl ConnectionInner {
     ) -> Result<(), msquic::Status> {
         trace!("ConnectionInner({:p}) App shutdown {}", self, error_code);
 
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.state = ConnectionState::Shutdown;
         exclusive.error = Some(ConnectionError::ShutdownByPeer(error_code));
         exclusive
@@ -845,7 +856,7 @@ impl ConnectionInner {
         );
 
         {
-            let mut exclusive = self.exclusive.lock().unwrap();
+            let mut exclusive = self.exclusive.lock_poison_tolerant();
             exclusive.state = ConnectionState::ShutdownComplete;
             if exclusive.error.is_none() {
                 exclusive.error = Some(ConnectionError::ShutdownByLocal);
@@ -897,18 +908,26 @@ impl ConnectionInner {
             == msquic::StreamOpenFlags::UNIDIRECTIONAL
         {
             if let (Some(read_stream), None) = stream.split() {
-                let mut exclusive = self.exclusive.lock().unwrap();
+                let mut exclusive = self.exclusive.lock_poison_tolerant();
                 exclusive.inbound_uni_streams.push_back(read_stream);
                 exclusive
                     .inbound_uni_stream_waiters
                     .drain(..)
                     .for_each(|waker| waker.wake());
             } else {
-                unreachable!();
+                // A unidirectional stream opened by the peer must always split
+                // into exactly a read half. This should be unreachable, but a
+                // callback must never panic across the FFI boundary, so reject
+                // the stream with an error status instead of aborting.
+                error!(
+                    "ConnectionInner({:p}) peer unidirectional stream did not split into a read stream",
+                    self
+                );
+                return Err(msquic::StatusCode::QUIC_STATUS_INTERNAL_ERROR.into());
             }
         } else {
             {
-                let mut exclusive = self.exclusive.lock().unwrap();
+                let mut exclusive = self.exclusive.lock_poison_tolerant();
                 exclusive.inbound_streams.push_back(stream);
                 exclusive
                     .inbound_stream_waiters
@@ -945,7 +964,7 @@ impl ConnectionInner {
             send_enabled,
             max_send_length
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.dgram_send_enabled = send_enabled;
         exclusive.dgram_max_send_length = max_send_length;
         Ok(())
@@ -959,7 +978,7 @@ impl ConnectionInner {
         trace!("ConnectionInner({:p}) Datagram received", self);
         let buf = Bytes::copy_from_slice(buffer.as_bytes());
         {
-            let mut exclusive = self.exclusive.lock().unwrap();
+            let mut exclusive = self.exclusive.lock_poison_tolerant();
             exclusive.recv_buffers.push_back(buf);
             exclusive
                 .recv_waiters
@@ -982,7 +1001,7 @@ impl ConnectionInner {
         match state {
             msquic::DatagramSendState::Sent | msquic::DatagramSendState::Canceled => {
                 let mut write_buf = unsafe { WriteBuffer::from_raw(client_context) };
-                let mut exclusive = self.exclusive.lock().unwrap();
+                let mut exclusive = self.exclusive.lock_poison_tolerant();
                 write_buf.reset();
                 exclusive.write_pool.push(write_buf);
             }
@@ -997,15 +1016,22 @@ impl ConnectionInner {
         local_address: &msquic::Addr,
         observed_address: &msquic::Addr,
     ) -> Result<(), msquic::Status> {
-        let local_address = local_address.as_socket().expect("socket addr");
-        let observed_address = observed_address.as_socket().expect("socket addr");
+        let (Some(local_address), Some(observed_address)) =
+            (local_address.as_socket(), observed_address.as_socket())
+        else {
+            error!(
+                "ConnectionInner({:p}) Notify observed address with non-socket address",
+                self
+            );
+            return Ok(());
+        };
         trace!(
             "ConnectionInner({:p}) Notify observed address local_address:{} observed_address:{}",
             self,
             local_address,
             observed_address
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive
             .events
             .push_back(ConnectionEvent::NotifyObservedAddress {
@@ -1025,14 +1051,20 @@ impl ConnectionInner {
         address: &msquic::Addr,
         sequence_number: u64,
     ) -> Result<(), msquic::Status> {
-        let address = address.as_socket().expect("socket addr");
+        let Some(address) = address.as_socket() else {
+            error!(
+                "ConnectionInner({:p}) Notify remote address added with non-socket address",
+                self
+            );
+            return Ok(());
+        };
         trace!(
             "ConnectionInner({:p}) Notify remote address added address:{} sequence_number:{}",
             self,
             address,
             sequence_number
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive
             .events
             .push_back(ConnectionEvent::NotifyRemoteAddressAdded {
@@ -1052,15 +1084,22 @@ impl ConnectionInner {
         local_address: &msquic::Addr,
         remote_address: &msquic::Addr,
     ) -> Result<(), msquic::Status> {
-        let local_address = local_address.as_socket().expect("socket addr");
-        let remote_address = remote_address.as_socket().expect("socket addr");
+        let (Some(local_address), Some(remote_address)) =
+            (local_address.as_socket(), remote_address.as_socket())
+        else {
+            error!(
+                "ConnectionInner({:p}) path validated with non-socket address",
+                self
+            );
+            return Ok(());
+        };
         trace!(
             "ConnectionInner({:p}) path validated local_address:{} remote_address:{}",
             self,
             local_address,
             remote_address
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.events.push_back(ConnectionEvent::PathValidated {
             local_address,
             remote_address,
@@ -1082,7 +1121,7 @@ impl ConnectionInner {
             self,
             sequence_number
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive
             .events
             .push_back(ConnectionEvent::NotifyRemoteAddressRemoved { sequence_number });
@@ -1094,6 +1133,22 @@ impl ConnectionInner {
     }
 
     fn callback_handler_impl(
+        &self,
+        connection: msquic::ConnectionRef,
+        ev: msquic::ConnectionEvent,
+    ) -> Result<(), msquic::Status> {
+        // This runs on a MsQuic-owned thread, invoked through an `extern "C"`
+        // trampoline. A panic unwinding across that FFI boundary is undefined
+        // behavior, so contain any panic here and turn it into an error status.
+        catch_unwind(AssertUnwindSafe(|| self.dispatch_event(connection, ev))).unwrap_or_else(
+            |_| {
+                error!("ConnectionInner({:p}) panic in callback handler", self);
+                Err(msquic::StatusCode::QUIC_STATUS_INTERNAL_ERROR.into())
+            },
+        )
+    }
+
+    fn dispatch_event(
         &self,
         _connection: msquic::ConnectionRef,
         ev: msquic::ConnectionEvent,
@@ -1311,7 +1366,7 @@ impl Future for OpenOutboundStream<'_> {
             ..
         } = *this;
 
-        let mut exclusive = conn.inner.exclusive.lock().unwrap();
+        let mut exclusive = conn.inner.exclusive.lock_poison_tolerant();
         match exclusive.state {
             ConnectionState::Open => {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -5,6 +5,7 @@ mod buffer;
 mod connection;
 mod listener;
 mod stream;
+mod sync;
 
 #[cfg(feature = "msquic-latest")]
 pub use msquic;

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -195,12 +195,17 @@ struct ListenerInnerExclusive {
     shutdown_complete_waiters: Vec<Waker>,
     sslkeylog_file: Option<std::fs::File>,
 }
+// SAFETY: the only non-auto-`Send`/`Sync` members are MsQuic handles, which are
+// documented to be thread-safe, and are always accessed under the enclosing
+// `Mutex`. Sharing this state across threads is therefore sound.
 unsafe impl Sync for ListenerInnerExclusive {}
 unsafe impl Send for ListenerInnerExclusive {}
 
 struct ListenerInnerShared {
     configuration: msquic::Configuration,
 }
+// SAFETY: `Configuration` wraps a MsQuic handle that MsQuic documents as
+// thread-safe, so it is sound to move and share across threads.
 unsafe impl Sync for ListenerInnerShared {}
 unsafe impl Send for ListenerInnerShared {}
 

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1,5 +1,6 @@
 use crate::buffer::{StreamRecvBuffer, WriteBuffer};
 use crate::connection::ConnectionError;
+use crate::sync::LockPoisonTolerant;
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -9,6 +10,8 @@ use seera_msquic as msquic;
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
+use std::ops::Range;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, RwLock};
 use std::task::{ready, Context, Poll, Waker};
@@ -17,7 +20,7 @@ use bytes::Bytes;
 use libc::c_void;
 use rangemap::RangeSet;
 use thiserror::Error;
-use tracing::trace;
+use tracing::{error, trace};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StreamType {
@@ -102,7 +105,7 @@ impl Stream {
         cx: &mut Context,
         failed_on_block: bool,
     ) -> Poll<Result<(), StartError>> {
-        let mut exclusive = self.0.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.0.inner.exclusive.lock_poison_tolerant();
         trace!(
             "Stream(Inner: {:p}) poll_start state={:?}",
             self.0.inner,
@@ -550,7 +553,7 @@ impl StreamInstance {
         let res;
         let mut read_complete_buffers = Vec::new();
         {
-            let mut exclusive = self.inner.exclusive.lock().unwrap();
+            let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
             match exclusive.recv_state {
                 StreamRecvState::Closed => {
                     return Poll::Ready(Err(ReadError::Closed));
@@ -672,7 +675,7 @@ impl StreamInstance {
     where
         T: FnMut(&mut WriteBuffer) -> WriteStatus<U>,
     {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::Closed => {
                 return Poll::Ready(Err(WriteError::Closed));
@@ -701,44 +704,41 @@ impl StreamInstance {
             let (data, len) = write_buf.get_buffers();
             std::slice::from_raw_parts(data, len)
         };
-        match status {
+        let (send_flags, val, finish) = match status {
             WriteStatus::Writable(val) | WriteStatus::Blocked(Some(val)) => {
-                match unsafe {
-                    self.msquic_stream.send(
-                        buffers,
-                        msquic::SendFlags::NONE,
-                        write_buf.into_raw() as *const _,
-                    )
-                }
-                .map_err(WriteError::OtherError)
-                {
-                    Ok(()) => Poll::Ready(Ok(Some(val))),
-                    Err(e) => Poll::Ready(Err(e)),
-                }
+                (msquic::SendFlags::NONE, Some(val), false)
             }
             WriteStatus::Blocked(None) => unreachable!(),
-            WriteStatus::Finished(val) => {
-                match unsafe {
-                    self.msquic_stream.send(
-                        buffers,
-                        msquic::SendFlags::FIN,
-                        write_buf.into_raw() as *const _,
-                    )
+            WriteStatus::Finished(val) => (msquic::SendFlags::FIN, val, true),
+        };
+        // Ownership of `write_buf` is handed to MsQuic, which returns it in the
+        // SendComplete callback. On an error MsQuic never took it and no
+        // completion will fire, so we must reclaim it here to avoid leaking the
+        // buffer (and any zerocopy `Bytes` it holds) on every failed send.
+        let raw = write_buf.into_raw();
+        match unsafe {
+            self.msquic_stream
+                .send(buffers, send_flags, raw as *const _)
+        }
+        .map_err(WriteError::OtherError)
+        {
+            Ok(()) => {
+                if finish {
+                    exclusive.send_state = StreamSendState::Shutdown;
                 }
-                .map_err(WriteError::OtherError)
-                {
-                    Ok(()) => {
-                        exclusive.send_state = StreamSendState::Shutdown;
-                        Poll::Ready(Ok(val))
-                    }
-                    Err(e) => Poll::Ready(Err(e)),
-                }
+                Poll::Ready(Ok(val))
+            }
+            Err(e) => {
+                let mut write_buf = unsafe { WriteBuffer::from_raw(raw) };
+                write_buf.reset();
+                exclusive.write_pool.push(write_buf);
+                Poll::Ready(Err(e))
             }
         }
     }
 
     fn poll_finish_write(&self, cx: &mut Context<'_>) -> Poll<Result<(), WriteError>> {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::Start => {
                 exclusive.start_waiters.push(cx.waker().clone());
@@ -779,7 +779,7 @@ impl StreamInstance {
         cx: &mut Context<'_>,
         error_code: u64,
     ) -> Poll<Result<(), WriteError>> {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::Start => {
                 exclusive.start_waiters.push(cx.waker().clone());
@@ -816,7 +816,7 @@ impl StreamInstance {
     }
 
     fn abort_write(&self, error_code: u64) -> Result<(), WriteError> {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::StartComplete => {
                 self.msquic_stream
@@ -834,7 +834,7 @@ impl StreamInstance {
         cx: &mut Context<'_>,
         error_code: u64,
     ) -> Poll<Result<(), ReadError>> {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.recv_state {
             StreamRecvState::Start => {
                 exclusive.start_waiters.push(cx.waker().clone());
@@ -871,7 +871,7 @@ impl StreamInstance {
     }
 
     fn abort_read(&self, error_code: u64) -> Result<(), ReadError> {
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.recv_state {
             StreamRecvState::StartComplete => {
                 self.msquic_stream
@@ -895,37 +895,13 @@ impl StreamInstance {
             buffer_range.end - buffer_range.start
         );
 
-        let mut exclusive = self.inner.exclusive.lock().unwrap();
-        if !buffer_range.is_empty() {
-            exclusive.read_complete_map.insert(buffer_range);
-        }
-        let complete_len = if let Some(complete_range) = exclusive.read_complete_map.first() {
-            trace!(
-                "StreamInstance({:p}) complete read offset={} len={}",
-                self,
-                complete_range.start,
-                complete_range.end - complete_range.start
-            );
-
-            if complete_range.start == 0 && exclusive.read_complete_cursor < complete_range.end {
-                let complete_len = complete_range.end - exclusive.read_complete_cursor;
-                exclusive.read_complete_cursor = complete_range.end;
-                Some(complete_len)
-            } else if complete_range.start == 0
-                && exclusive.read_complete_cursor == complete_range.end
-                && buffer.offset() == complete_range.end
-                && buffer.is_empty()
-                && buffer.fin()
-            {
-                Some(0)
-            } else {
-                None
-            }
-        } else if buffer.is_empty() && buffer.fin() {
-            Some(0)
-        } else {
-            None
-        };
+        let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
+        let complete_len = exclusive.register_read_complete(
+            buffer_range,
+            buffer.offset(),
+            buffer.is_empty(),
+            buffer.fin(),
+        );
         if let Some(complete_len) = complete_len {
             trace!(
                 "StreamInstance({:p}) call receive_complete len={}",
@@ -940,7 +916,7 @@ impl StreamInstance {
 impl Drop for StreamInstance {
     fn drop(&mut self) {
         trace!("StreamInstance({:p}) dropping", self);
-        let exclusive = self.inner.exclusive.lock().unwrap();
+        let exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.state {
             StreamState::Start | StreamState::StartComplete => {
                 trace!(
@@ -981,6 +957,51 @@ struct StreamInnerExclusive {
     start_waiters: Vec<Waker>,
     read_waiters: Vec<Waker>,
     write_shutdown_waiters: Vec<Waker>,
+}
+
+impl StreamInnerExclusive {
+    /// Registers a completed buffer range and returns the number of bytes that
+    /// have become contiguously completable from the front of the receive
+    /// stream, if any.
+    ///
+    /// MsQuic reclaims received bytes cumulatively from the front of the stream,
+    /// so a range must never be reported as complete while an earlier range is
+    /// still outstanding (e.g. a chunk the application still holds). Tracking
+    /// completed ranges in `read_complete_map` and only advancing
+    /// `read_complete_cursor` over the contiguous prefix guarantees that, which
+    /// in turn prevents MsQuic from freeing memory the application still
+    /// references (a use-after-free).
+    fn register_read_complete(
+        &mut self,
+        buffer_range: Range<usize>,
+        buffer_offset: usize,
+        buffer_is_empty: bool,
+        buffer_fin: bool,
+    ) -> Option<usize> {
+        if !buffer_range.is_empty() {
+            self.read_complete_map.insert(buffer_range);
+        }
+        if let Some(complete_range) = self.read_complete_map.first() {
+            if complete_range.start == 0 && self.read_complete_cursor < complete_range.end {
+                let complete_len = complete_range.end - self.read_complete_cursor;
+                self.read_complete_cursor = complete_range.end;
+                Some(complete_len)
+            } else if complete_range.start == 0
+                && self.read_complete_cursor == complete_range.end
+                && buffer_offset == complete_range.end
+                && buffer_is_empty
+                && buffer_fin
+            {
+                Some(0)
+            } else {
+                None
+            }
+        } else if buffer_is_empty && buffer_fin {
+            Some(0)
+        } else {
+            None
+        }
+    }
 }
 
 struct StreamInnerShared {
@@ -1065,7 +1086,7 @@ impl StreamInner {
             peer_accepted,
             id,
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.start_status = Some(status.clone());
         if status.is_ok() && peer_accepted {
             exclusive.state = StreamState::StartComplete;
@@ -1107,7 +1128,7 @@ impl StreamInner {
             (flags & msquic::ReceiveFlags::FIN) == msquic::ReceiveFlags::FIN,
         );
 
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.recv_len += *total_buffer_length as usize;
         exclusive.recv_buffers.push_back(recv_buffer);
         exclusive
@@ -1129,7 +1150,7 @@ impl StreamInner {
         );
 
         let mut write_buf = unsafe { WriteBuffer::from_raw(client_context) };
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         write_buf.reset();
         exclusive.write_pool.push(write_buf);
         Ok(())
@@ -1141,7 +1162,7 @@ impl StreamInner {
             self,
             self.shared.id.read()
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.recv_state = StreamRecvState::ShutdownComplete;
         exclusive
             .read_waiters
@@ -1156,7 +1177,7 @@ impl StreamInner {
             self,
             self.shared.id.read()
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.recv_state = StreamRecvState::ShutdownComplete;
         exclusive.recv_error_code = Some(error_code);
         exclusive
@@ -1172,7 +1193,7 @@ impl StreamInner {
             self,
             self.shared.id.read()
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.send_state = StreamSendState::ShutdownComplete;
         exclusive.send_error_code = Some(error_code);
         exclusive
@@ -1188,7 +1209,7 @@ impl StreamInner {
             self,
             self.shared.id.read()
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.send_state = StreamSendState::ShutdownComplete;
         exclusive
             .write_shutdown_waiters
@@ -1214,19 +1235,43 @@ impl StreamInner {
             self.shared.id.read()
         );
         {
-            let mut exclusive = self.exclusive.lock().unwrap();
+            let mut exclusive = self.exclusive.lock_poison_tolerant();
 
+            // Guard against a second ShutdownComplete: the receive-completion
+            // accounting below must run exactly once.
+            if exclusive.state == StreamState::ShutdownComplete {
+                return Ok(());
+            }
+
+            // Complete the receive buffers that were never delivered to the
+            // application. We must NOT blindly complete `recv_len -
+            // read_complete_cursor`: that range also covers chunks the
+            // application has taken but not yet dropped, and completing those
+            // bytes would let MsQuic free memory those chunks still point into
+            // (use-after-free). Feeding each undelivered buffer through the same
+            // contiguous-completion accounting as `read_complete` only completes
+            // bytes that are safe to reclaim now; any bytes still held by the
+            // application are left to complete when their chunk is dropped.
             if !exclusive.recv_buffers.is_empty() {
-                trace!(
-                    "StreamInner({:p}) read complete {}",
-                    self,
-                    exclusive.recv_len - exclusive.read_complete_cursor
-                );
-                exclusive.recv_buffers.clear();
-                if !app_close_in_progress {
-                    msquic_stream.receive_complete(
-                        (exclusive.recv_len - exclusive.read_complete_cursor) as u64,
+                let recv_buffers = std::mem::take(&mut exclusive.recv_buffers);
+                for buffer in &recv_buffers {
+                    let complete_len = exclusive.register_read_complete(
+                        buffer.range(),
+                        buffer.offset(),
+                        buffer.is_empty(),
+                        buffer.fin(),
                     );
+                    if let Some(complete_len) = complete_len {
+                        trace!(
+                            "StreamInner({:p}) shutdown receive_complete len={}",
+                            self,
+                            complete_len
+                        );
+                        // Once the app is tearing down MsQuic must not be called.
+                        if !app_close_in_progress {
+                            msquic_stream.receive_complete(complete_len as u64);
+                        }
+                    }
                 }
             }
 
@@ -1280,7 +1325,7 @@ impl StreamInner {
             self,
             self.shared.id.read()
         );
-        let mut exclusive = self.exclusive.lock().unwrap();
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
         exclusive.state = StreamState::StartComplete;
         if self.shared.stream_type == StreamType::Bidirectional {
             exclusive.recv_state = StreamRecvState::StartComplete;
@@ -1294,6 +1339,22 @@ impl StreamInner {
     }
 
     fn callback_handler_impl(
+        &self,
+        msquic_stream: msquic::StreamRef,
+        ev: msquic::StreamEvent,
+    ) -> Result<(), msquic::Status> {
+        // This runs on a MsQuic-owned thread, invoked through an `extern "C"`
+        // trampoline. A panic unwinding across that FFI boundary is undefined
+        // behavior, so contain any panic here and turn it into an error status.
+        catch_unwind(AssertUnwindSafe(|| self.dispatch_event(msquic_stream, ev))).unwrap_or_else(
+            |_| {
+                error!("StreamInner({:p}) panic in callback handler", self);
+                Err(msquic::StatusCode::QUIC_STATUS_INTERNAL_ERROR.into())
+            },
+        )
+    }
+
+    fn dispatch_event(
         &self,
         msquic_stream: msquic::StreamRef,
         ev: msquic::StreamEvent,

--- a/msquic-async/src/sync.rs
+++ b/msquic-async/src/sync.rs
@@ -1,0 +1,19 @@
+use std::sync::{Mutex, MutexGuard};
+
+/// Extension trait for locking a [`Mutex`] while tolerating poisoning.
+///
+/// MsQuic callbacks run on MsQuic-owned threads. If a handler ever panics, the
+/// mutex it held would be left poisoned, and a plain `lock().unwrap()` in every
+/// later callback (or API call) would panic in turn, permanently wedging the
+/// connection — a denial of service. Recovering the guard from a poisoned lock
+/// keeps the connection usable; the protected state is always left consistent
+/// before any `?`/panic can escape a critical section.
+pub(crate) trait LockPoisonTolerant<T> {
+    fn lock_poison_tolerant(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> LockPoisonTolerant<T> for Mutex<T> {
+    fn lock_poison_tolerant(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}


### PR DESCRIPTION
Addresses the five findings from an upstream security review (filed as [seera-networks/ISEKAI-link-server#151](https://github.com/seera-networks/ISEKAI-link-server/issues/151)).

## Findings & fixes

### 1. HIGH — `receive_complete` over app-held buffers → use-after-free (`stream.rs`)
`handle_event_shutdown_complete` completed `recv_len - read_complete_cursor` bytes, which also covers chunks the application has taken but not yet dropped. Because MsQuic reclaims received bytes cumulatively from the front, this could free memory the app still references.

- Extracted the contiguous-completion accounting into `register_read_complete`, shared by the `read_complete` (drop) path and shutdown.
- On shutdown, only the **undelivered** buffers are fed through that accounting; app-held bytes remain and complete when their chunk is dropped.
- The cursor now advances correctly (fixes the secondary double-`receive_complete`), and a re-entry guard skips work after `ShutdownComplete`.

### 2. MEDIUM — panics unwind across the FFI boundary (UB) / mutex poisoning → DoS
The binding trampoline does not `catch_unwind`, so a panic in a handler is UB; and the first panic poisons the mutex, wedging the connection permanently.

- Wrap stream/connection event dispatch in `catch_unwind` (panic → `QUIC_STATUS_INTERNAL_ERROR`).
- New `sync::LockPoisonTolerant` used for every exclusive lock (poison-tolerant).
- Replace callback-reachable `unreachable!`/`expect` with graceful handling.

### 3. MEDIUM — `WriteBuffer` leaked on failed send / datagram_send
On an error MsQuic delivers no completion, so the buffer leaked. Now reclaimed (`from_raw`) on the error branch and returned to the pool. Also added the missing `dgram_send_enabled`/`max_send_length` checks to `poll_send_datagram`.

### 4. MEDIUM — h3-client example disabled certificate validation
Validates against the bundled self-signed cert by default; `NO_CERTIFICATE_VALIDATION` is now an explicit, documented test-only opt-in (`H3_CLIENT_INSECURE`).

### 5. LOW
- Clamp the TLS-secret slice to `QUIC_TLS_SECRETS_MAX_SECRET_LEN` to avoid an out-of-bounds panic.
- Add `// SAFETY:` notes to the raw-pointer `Send`/`Sync` impls.

## Verification
Verified with the `msquic-seera` feature set (as CI uses):
- `cargo check` / `cargo clippy --all-targets`: no warnings or errors for `msquic-async` and the h3 examples.
- `cargo test -p msquic-async`: **25 passed** (incl. multi-receive, datagram, and shutdown paths).

Submodule pointers are intentionally not touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)