### PR TITLE
Add Registration wrapper with wait_idle() for safe teardown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "h3-msquic-async"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "msquic-async"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2.153"
 msquic = { version = "2.6.0-beta", path = "./msquic" }
 msquic-v2-5 = { package = "msquic", version = "2.5.1-beta" }
 seera-msquic = { version = "2.6.0-beta2", path = "./seera-msquic" }
-msquic-async = { version = "0.4.1", path = "./msquic-async", default-features = false }
+msquic-async = { version = "0.5.0", path = "./msquic-async", default-features = false }
 rangemap = "1.5.1"
 schannel = "0.1.27"
 tempfile = "3.10.1"

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Note that MsQuic, which is used to implement QUIC, needs to be built and linked.
 ### Windows, Linux, MacOS
 Add msquic-async in dependencies of your Cargo.toml.
 ```toml
-msquic-async = { version = "0.4.0" }
+msquic-async = { version = "0.5.0" }
 ```
 
 If you use SEERA MsQuic for the backend, please specify `msquic-seera` feature with
 `default-features = false`.
 ```toml
-msquic-async = { version = "0.4.0", default-features = false, features = ["tokio", "msquic-seera"] }
+msquic-async = { version = "0.5.0", default-features = false, features = ["tokio", "msquic-seera"] }
 ```
 
 The [examples](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-async/examples) directory can help get started.
@@ -25,13 +25,12 @@ The [examples](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-asyn
 ### Server
 
 ```rust
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("sample")];
 
     // create msquic-async listener
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()
@@ -155,11 +154,10 @@ You can find a full server example in [`msquic-async/examples/server.rs`](https:
 ### Client
 
 ``` rust
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("sample")];
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()
@@ -189,6 +187,27 @@ You can find a full server example in [`msquic-async/examples/server.rs`](https:
 ```
 
 You can find a full client example in [`msquic-async/examples/client.rs`](https://github.com/masa-koz/msquic-async-rs/tree/main/msquic-async/examples/client.rs)
+
+### Shutdown
+
+Dropping a registration calls `RegistrationClose`, which **blocks until every
+connection, listener and configuration created from it has been closed**. Since
+neither `shutdown()` nor the shutdown-complete events close a handle, use
+`Registration::wait_idle()` to observe that point:
+
+```rust
+    registration.shutdown();       // queue shutdown on all connections, stop all listeners
+    registration.wait_idle().await; // every Connection/Listener handle is now closed
+    drop(configuration);           // configurations are not tracked; drop them here
+    drop(registration);            // returns promptly
+```
+
+`wait_idle()` tracks every `msquic_async::Connection` (including clones) and
+`Listener`. It does not track `Configuration`s -- `ConfigurationClose` only
+drops the application's reference while connections hold their own, so a tracked
+configuration would report idle too early. A `Listener` owns the configuration
+passed to it, so only application-owned client configurations need the manual
+`drop` above. Streams are not tracked either; see the crate docs for details.
 
 ## License
 

--- a/docs/registration-wait-idle-design.md
+++ b/docs/registration-wait-idle-design.md
@@ -1,0 +1,431 @@
+# Design: `msquic_async::Registration` and `wait_idle()`
+
+Status: implemented
+Target crate: `msquic-async` (0.4.1 → 0.5.0, breaking)
+Prior art: [`msquic-h3` commit `b4be2599`](https://github.com/youyuanwu/msquic-h3/commit/b4be2599d1b18710d79dec314817555efaa73668)
+
+## 1. Problem
+
+Dropping a `msquic::Registration` blocks — potentially forever — unless every
+child handle derived from it has already been closed.
+
+The upstream binding's `Drop` calls `RegistrationClose` unconditionally
+(`msquic/src/rs/lib.rs:807-811`):
+
+```rust
+fn close_inner(&self) {
+    if !self.handle.is_null() {
+        unsafe { Api::ffi_ref().RegistrationClose.unwrap()(self.handle) }
+    }
+}
+```
+
+In the core library that lands in `CxPlatRundownReleaseAndWait`
+(`msquic/src/core/registration.c:53`), a *synchronous, uninterruptible* wait on
+a rundown reference that every child object holds:
+
+| Child | Acquire | Release |
+| --- | --- | --- |
+| Connection | `connection.c:524` (`QuicConnRegister`) | `connection.c:411`, `:502`, `:547` (via `ConnectionClose`) |
+| Listener | `listener.c:93` (`QuicListenerOpen`) | `listener.c:104`, `:167` (via `ListenerClose`) |
+| Configuration | `configuration.c:204` (`QuicConfigurationOpen`) | `configuration.c:271`, only at refcount 0 |
+
+Two properties make this hard to get right from application code:
+
+1. **`RegistrationShutdown` closes nothing.** `Registration::shutdown()` queues
+   shutdown on connections and stops listeners, but the handles — and their
+   rundown references — stay alive until the Rust values are dropped.
+2. **`SHUTDOWN_COMPLETE` is not close.** `msquic-async` sets
+   `ConnectionState::ShutdownComplete` in `handle_event_shutdown_complete()`
+   (`msquic-async/src/connection.rs:848`) and `ListenerState::ShutdownComplete`
+   in `handle_event_stop_complete()` (`listener.rs:309`), but neither handler
+   closes a handle. Any application-level "wait for shutdown" built on these
+   events fires *before* the rundown reference is released, and is therefore
+   racy.
+
+So today the only correct teardown rule is an unwritten one: *drop every
+`Listener`, every clone of every `Connection`, and every `Configuration` before
+the `Registration` goes out of scope.* Nothing in the crate enforces it, nothing
+detects a violation, and the failure mode is a silent hang inside `Drop`.
+
+This is aggravated by `Connection` being `Clone` (`Connection(Arc<ConnectionInstance>)`,
+`connection.rs:27`). `h3-msquic-async` clones it into four boxed unfold futures
+plus `OpenStreams` (`h3-msquic-async/src/lib.rs:44-58`, `:221-228`), so "the
+application dropped its `Connection`" says nothing about whether
+`ConnectionClose` has run.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Provide `Registration::wait_idle()`, an async signal that resolves once no
+  `msquic-async` connection or listener holds the registration rundown.
+- Make it structurally impossible to create an untracked connection or listener,
+  by routing every construction path through the wrapper.
+- Keep the tracking free of dependencies beyond `std`, usable from any executor,
+  and correct under an arbitrary number of concurrent waiters.
+
+**Non-goals**
+
+- Tracking `Configuration` handles. See §7 — a configuration guard would report
+  idle *too early*, which is worse than not tracking at all.
+- Making `Registration::drop` non-blocking, or adopting `RegistrationClose2`.
+  The FFI entry exists (`msquic/src/rs/ffi/linux_bindings.rs:6726`) but is
+  unused by the binding; wrapping it is a separate change.
+- Fixing the `Stream`-outlives-`Connection` hazard (§9).
+
+## 3. Design overview
+
+A new private module `msquic-async/src/registration.rs` introduces four types,
+mirroring the `msquic-h3` design:
+
+- **`RundownState`** — `AtomicUsize` count of live reservations plus a
+  `Mutex<Waiters>` waker table. Owned by the `Registration`, cloned via `Arc`
+  into every tracked handle.
+- **`RundownGuard`** — RAII token. Increments on construction, decrements on
+  drop, and wakes all waiters on the `1 → 0` edge.
+- **`Registration`** — public wrapper owning `msquic::Registration` plus
+  `Arc<RundownState>`. The raw handle is *not* public.
+- **`WaitIdle`** — the `Future` returned by `wait_idle()`, supporting any number
+  of concurrent waiters via a keyed waker map.
+
+The counter is a conservative over-approximation of the native rundown: we
+reserve *before* opening a handle and release *after* closing it, so `active == 0`
+implies the native rundown holds no `msquic-async` object, never the reverse.
+
+The implementation of these four types can be taken essentially verbatim from
+`msquic-h3/src/registration.rs`; the interesting work in this crate is §5–§7.
+
+## 4. Public API
+
+```rust
+// msquic-async/src/lib.rs
+mod registration;
+pub use registration::{Registration, WaitIdle};
+```
+
+```rust
+impl Registration {
+    /// Open a registration and its rundown tracking state.
+    pub fn new(config: &msquic::RegistrationConfig) -> Result<Self, msquic::Status>;
+
+    /// Queue shutdown on all connections and stop all listeners. Non-blocking,
+    /// and closes nothing — pair it with `wait_idle()`.
+    pub fn shutdown(&self);
+
+    /// Open a `Configuration` against this registration.
+    ///
+    /// Required because the raw registration handle is not public. The returned
+    /// `Configuration` is deliberately untracked: drop it *after* `wait_idle()`
+    /// resolves and *before* dropping the `Registration`.
+    pub fn open_configuration(
+        &self,
+        alpn: &[msquic::BufferRef],
+        settings: Option<&msquic::Settings>,
+    ) -> Result<msquic::Configuration, msquic::Status>;
+
+    /// Resolves once no `msquic-async` `Connection` or `Listener` holds this
+    /// registration's rundown.
+    pub fn wait_idle(&self) -> WaitIdle;
+
+    pub(crate) fn raw(&self) -> &msquic::Registration;
+    pub(crate) fn state(&self) -> &Arc<RundownState>;
+}
+
+impl Future for WaitIdle { type Output = (); }
+```
+
+Changed constructors:
+
+| Before | After |
+| --- | --- |
+| `Connection::new(&msquic::Registration)` | `Connection::new(&crate::Registration)` |
+| `Listener::new(&msquic::Registration, msquic::Configuration)` | `Listener::new(&crate::Registration, msquic::Configuration)` |
+| `msquic::Configuration::open(&registration, alpn, settings)` | `registration.open_configuration(alpn, settings)` |
+
+**Additionally proposed for this crate** (not present in the prior art): a
+diagnostic `Drop` on `Registration` that logs before the blocking close, so the
+hang this design prevents is at least identifiable when it is reintroduced:
+
+```rust
+impl Drop for Registration {
+    fn drop(&mut self) {
+        let active = self.state.active.load(Ordering::Acquire);
+        if active != 0 {
+            tracing::warn!(
+                active,
+                "Registration dropped with live handles; RegistrationClose will block. \
+                 Call shutdown() then wait_idle().await before dropping."
+            );
+        }
+    }
+}
+```
+
+`tracing` is already a dependency, so this costs nothing.
+
+## 5. Guard placement — the load-bearing part
+
+A guard must decrement **after** the `*Close` it protects, and **only when the
+last owner of the handle is gone**. Field drop order in Rust is declaration
+order, so the guard is declared *after* the handle field.
+
+### 5.1 `Connection`
+
+`Connection` is `Arc<ConnectionInstance>` and `Clone`. The guard therefore
+belongs in `ConnectionInstance`, not in `Connection`:
+
+```rust
+struct ConnectionInstance {
+    inner: Arc<ConnectionInner>,
+    msquic_conn: msquic::Connection,
+    // Declared last: `msquic_conn`'s ConnectionClose releases the native
+    // rundown ref before this guard decrements and wakes wait_idle waiters.
+    _guard: RundownGuard,
+}
+```
+
+This is exactly the correction the prior art calls out: binding the decrement to
+a user-facing wrapper's `Drop` is wrong when the handle lives behind a shared
+`Arc`. Here the last `Arc<ConnectionInstance>` clone — including the ones inside
+`h3-msquic-async`'s boxed futures — triggers `ConnectionInstance::drop`, which
+drops `msquic_conn` (→ `ConnectionClose`, `msquic/src/rs/lib.rs:953`) and only
+then the guard.
+
+Note the callback closure captures `Arc<ConnectionInner>`, never
+`ConnectionInstance` (`connection.rs:36-38`), so there is no reference cycle
+keeping the guard alive.
+
+### 5.2 `Listener`
+
+```rust
+pub struct Listener {
+    inner: Arc<ListenerInner>,
+    msquic_listener: msquic::Listener,
+    _guard: RundownGuard,
+}
+```
+
+`Listener` is not `Clone`, so its own `Drop` is the last owner. Dropping
+`msquic_listener` runs `ListenerClose` (`msquic/src/rs/lib.rs:1133`), which
+drops the boxed callback closure → last `Arc<ListenerInner>` →
+`ListenerInnerShared.configuration` → `ConfigurationClose`, and drops any queued
+but never-accepted `Connection`s in `ListenerInnerExclusive.new_connections`.
+All of that happens before the guard decrements. See §7 for why this makes the
+server-side configuration safe for free.
+
+### 5.3 Inbound connections
+
+`ListenerInner::handle_event_new_connection` (`listener.rs:234`) constructs a
+`Connection` via `Connection::from_raw`, so it needs access to the state. Add it
+to `ListenerInnerShared`:
+
+```rust
+struct ListenerInnerShared {
+    configuration: msquic::Configuration,
+    rundown: Arc<RundownState>,
+}
+```
+
+and reserve immediately before the handle is handed to a `Connection`:
+
+```rust
+connection.set_configuration(&self.shared.configuration)?;
+let guard = RundownGuard::new(self.shared.rundown.clone());
+let new_conn = Connection::from_raw(connection, tls_secrets, sslkeylog_file, guard);
+```
+
+Reserving *here* rather than at the top of the callback is deliberate. There is
+no untracked window to close: this callback only runs while the `Listener` is
+alive, and the listener's own guard keeps `active >= 1` for its whole duration.
+Reserving at the top would instead introduce a drop-order bug on the `?` paths —
+`connection` is a function parameter and a top-of-function `guard` would be a
+local, and locals drop *before* parameters, so the guard would decrement before
+`ConnectionClose`. Reserving after the last `?` makes every early-return path
+trivially leak-free.
+
+`Connection::from_raw` gains a `guard: RundownGuard` parameter. It is
+`pub(crate)`, so this is not a public API change.
+
+## 6. Reservation ordering rules
+
+The rule is: **reserve before the native acquire, release after the native
+release.**
+
+- **`Listener::new`** — reserve before `msquic::Listener::open`, because
+  `QuicListenerOpen` acquires the rundown before returning (`listener.c:93`). If
+  `open` fails, the local guard drops and releases.
+- **`Connection::new`** — reserve before `msquic::Connection::open`. Note that
+  `QuicConnRegister` (`connection.c:524`) actually runs at `open` time for
+  client connections, so reserving first closes the window.
+- **Inbound** — reserve after the last fallible step of the `NewConnection`
+  callback; see §5.3 for why that is both sufficient and safer.
+
+`msquic-async` is simpler than the prior art here in one respect. `msquic-h3`
+had to convert `Connection::connect` from `async fn` to a non-`async` function
+returning `impl Future`, so that the reservation happened when the future was
+*created* rather than when first polled — otherwise a queued-but-unpolled
+connect could open a native handle after `wait_idle` had already observed zero.
+This crate has no such function: `Connection::new` is already synchronous and
+`start()` operates on an already-open, already-tracked handle. **No signature
+needs to be de-`async`ed.**
+
+## 7. Why configurations stay untracked
+
+`ConfigurationClose` only drops the *application's* reference. Each connection
+takes its own via `QuicConfigurationAddRef`, and the rundown reference is
+released at `configuration.c:271` only when the refcount reaches zero. A guard
+attached to a `Configuration` wrapper would decrement at `ConfigurationClose`
+while the core object — and its rundown reference — is still alive, so
+`wait_idle()` could resolve while `RegistrationClose` would still block. That is
+strictly worse than the current situation, because it converts a documented
+ordering requirement into a silent lie.
+
+The contract therefore keeps one manual step: **drop configurations after
+`wait_idle()` resolves.**
+
+There is a pleasant consequence specific to this crate, though. `Listener::new`
+takes `configuration` **by value** and stores it in `ListenerInnerShared`
+(`listener.rs:204-206`). So for the server side:
+
+1. The listener's guard decrements only after `ListenerClose` → callback closure
+   dropped → `ListenerInner` dropped → `ConfigurationClose`.
+2. Each connection using that configuration releases its own config ref during
+   `ConnectionClose`, i.e. before its own guard decrements.
+
+Therefore when `active` reaches 0, the server configuration is fully released.
+**Only the client-side, application-owned `Configuration` passed to
+`Connection::start()` requires manual ordering.**
+
+## 8. Teardown contract
+
+Client:
+
+```rust
+let reg = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
+let config = reg.open_configuration(&alpn, Some(&settings))?;
+// ... use connections ...
+
+reg.shutdown();          // queue shutdown on all connections
+reg.wait_idle().await;   // all ConnectionClose calls have completed
+drop(config);            // now safe
+drop(reg);               // RegistrationClose returns promptly
+```
+
+Server:
+
+```rust
+listener.stop().await?;  // graceful; optional
+drop(listener);          // ListenerClose + ConfigurationClose
+reg.shutdown();
+reg.wait_idle().await;
+drop(reg);
+```
+
+The order `shutdown()` then `wait_idle()` matters: `wait_idle()` alone will hang
+if nothing has asked the connections to go away.
+
+## 9. Known gaps (pre-existing, documented not fixed)
+
+`Stream`, `ReadStream`, and `WriteStream` are `Arc<StreamInstance>` holding a
+`msquic::Stream` handle and **no reference at all** to the connection
+(`stream.rs:33`, `:419-421`; `Stream::open` borrows `&msquic::Connection`,
+`stream.rs:36-37`). A `Stream` can therefore outlive the last `Connection`
+clone, in which case `StreamClose` runs against an already-closed parent.
+
+This design does not change that, and deliberately does not add a stream-level
+guard: streams do not hold a registration rundown reference, so counting them
+would delay `wait_idle()` past the point the native rundown is already drained.
+The correct fix is to have `StreamInstance` hold an `Arc<ConnectionInstance>`,
+which is a separate change. Until then `wait_idle()` resolving does **not**
+imply all streams are closed.
+
+## 10. Memory ordering
+
+- Increment: `Relaxed` — no data is published by taking a reservation.
+- Decrement: `Release`, plus an `Acquire` fence on the observed `1 → 0` edge, so
+  the `*Close` that just ran is visible to whoever observes zero.
+- `WaitIdle::poll`: `Acquire` load.
+- Lost-wakeup window: `poll` registers its waker under the `Mutex<Waiters>` and
+  then **re-checks** `active`, so a guard that drained to zero between the
+  fast-path load and taking the lock cannot be missed.
+- `WaitIdle::drop` deregisters its slot, so a cancelled waiter does not leak an
+  entry in the waker map.
+
+## 11. Migration
+
+Breaking. Bump `msquic-async` to 0.5.0.
+
+Call sites to update in-tree:
+
+- `msquic-async/src/tests.rs` — 24 occurrences of
+  `msquic::Registration::new(...)`, plus the helper signatures at `:2068`,
+  `:2101` (`new_server`) and `:2158` (`new_client_config`), which take
+  `&msquic::Registration` and internally call `msquic::Configuration::open`.
+- `msquic-async/examples/{client,server}.rs` (`:17`, `:25`).
+- `h3-msquic-async/examples/{h3-client,h3-server}.rs` (`:20`/`:65`, `:36`/`:128`).
+- `README.md` (`:28`, `:158`) and `msquic-async/README.md`.
+
+`h3-msquic-async`'s library code needs no change: it wraps an already-built
+`msquic_async::Connection` and never touches a registration.
+
+Applications that today rely on drop order alone keep working if they update the
+type name — the wrapper is strictly additive at runtime — but they should adopt
+`shutdown()` + `wait_idle()` to get the guarantee.
+
+## 12. Testing
+
+Unit tests on `RundownState`/`RundownGuard`/`WaitIdle` (portable from the prior
+art, no msquic required):
+
+1. Idle from the start resolves immediately.
+2. A reservation keeps the future pending until dropped.
+3. Dropping a guard wakes a registered waiter.
+4. Multiple concurrent waiters all complete.
+5. A dropped waiter deregisters its slot.
+6. Nested reservations require all releases.
+
+Integration tests against real msquic, in `tests.rs`, all shipped:
+
+7. `test_registration_wait_idle_when_empty` — a registration with nothing
+   derived from it is idle immediately.
+8. `test_registration_wait_idle_tracks_listener` — pending while a `Listener`
+   is alive, *still pending after `stop()` completes* (the event is not a
+   close), and drains once the listener is dropped.
+9. `test_registration_wait_idle_tracks_unstarted_connection` — a `Connection`
+   that was never started is tracked.
+10. `test_registration_wait_idle_after_connection_closed` — the full
+    connect/shutdown/drop loop drains within a timeout. A timeout here is
+    exactly the `RegistrationClose` hang being prevented.
+11. `test_registration_wait_idle_tracks_connection_clones` — every clone must
+    go before the registration drains; this is the §5.1 case that
+    `h3-msquic-async` hits.
+12. `test_registration_wait_idle_tracks_unaccepted_connection` — a connection
+    accepted by MsQuic but never popped from `new_connections` keeps
+    `wait_idle()` pending until the listener is dropped.
+
+Not covered: a `set_configuration` failure in the inbound path. Under the final
+placement (§5.3) that path returns before any reservation exists, so there is no
+leak to test.
+
+## 13. Implementation checklist
+
+- [x] Add `msquic-async/src/registration.rs` with `RundownState`, `RundownGuard`,
+      `Registration`, `WaitIdle` + unit tests 1–6.
+- [x] Export `Registration`, `WaitIdle` from `lib.rs`.
+- [x] Add `_guard` to `ConnectionInstance` (declared after `msquic_conn`);
+      change `Connection::new` to take `&crate::Registration`; add the `guard`
+      parameter to `Connection::from_raw`.
+- [x] Add `_guard` to `Listener` (declared after `msquic_listener`) and
+      `rundown: Arc<RundownState>` to `ListenerInnerShared`; change
+      `Listener::new` to take `&crate::Registration`.
+- [x] Reserve in `handle_event_new_connection`.
+- [x] Add the diagnostic `Drop for Registration`.
+- [x] Update tests, examples, and both READMEs.
+- [x] Add integration tests 7–12.
+- [x] Bump `msquic-async` to 0.5.0 (and `h3-msquic-async` to 0.4.0, which
+      depends on the breaking version).
+
+Verified with `cargo clippy --workspace --all-targets` (clean) and
+`cargo test -p msquic-async` (34 tests + 1 doctest, all passing), plus clippy
+runs against the `msquic-2-5` and `msquic-seera` backends.

--- a/h3-msquic-async/Cargo.toml
+++ b/h3-msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3-msquic-async"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic-Async based library for using h3"

--- a/h3-msquic-async/examples/h3-client.rs
+++ b/h3-msquic-async/examples/h3-client.rs
@@ -17,11 +17,10 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("h3")];
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()

--- a/h3-msquic-async/examples/h3-server.rs
+++ b/h3-msquic-async/examples/h3-server.rs
@@ -33,13 +33,12 @@ async fn main() -> anyhow::Result<()> {
     let cmd_opts: CmdOptions = argh::from_env();
     let root = Arc::new(cmd_opts.root);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("h3")];
 
     // create msquic-async listener
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic-async"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Masahiro Kozuka <masa.koz@outlook.com>"]
 edition = "2021"
 description = "MsQuic based quic library that supports async operation"

--- a/msquic-async/examples/client.rs
+++ b/msquic-async/examples/client.rs
@@ -14,11 +14,10 @@ async fn main() -> anyhow::Result<()> {
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("sample")];
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()

--- a/msquic-async/examples/server.rs
+++ b/msquic-async/examples/server.rs
@@ -22,13 +22,12 @@ async fn main() -> anyhow::Result<()> {
 
     let _cmd_opts: CmdOptions = argh::from_env();
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default())?;
+    let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
 
     let alpn = [msquic::BufferRef::from("sample")];
 
     // create msquic-async listener
-    let configuration = msquic::Configuration::open(
-        &registration,
+    let configuration = registration.open_configuration(
         &alpn,
         Some(
             &msquic::Settings::new()

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,4 +1,5 @@
 use crate::buffer::WriteBuffer;
+use crate::registration::{Registration, RundownGuard};
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
 use crate::sync::LockPoisonTolerant;
 
@@ -31,14 +32,23 @@ impl Connection {
     /// Create a new connection.
     ///
     /// The connection is not started until `start` is called.
-    pub fn new(registration: &msquic::Registration) -> Result<Self, ConnectionError> {
+    pub fn new(registration: &Registration) -> Result<Self, ConnectionError> {
         let inner = Arc::new(ConnectionInner::new(ConnectionState::Open, None, None));
         let inner_in_ev = inner.clone();
-        let msquic_conn = msquic::Connection::open(registration, move |conn_ref, ev| {
+        // Reserve before opening: `QuicConnRegister` acquires the registration
+        // rundown during `ConnectionOpen`, so reserving first leaves no window
+        // in which a live native handle is untracked. If `open` fails, this
+        // guard drops and releases the reservation.
+        let guard = RundownGuard::new(registration.state().clone());
+        let msquic_conn = msquic::Connection::open(registration.raw(), move |conn_ref, ev| {
             inner_in_ev.callback_handler_impl(conn_ref, ev)
         })
         .map_err(ConnectionError::OtherError)?;
-        let instance = Arc::new(ConnectionInstance { inner, msquic_conn });
+        let instance = Arc::new(ConnectionInstance {
+            inner,
+            msquic_conn,
+            _guard: guard,
+        });
         trace!(
             "ConnectionInstance({:p}, Inner: {:p}) Open by local",
             instance,
@@ -52,6 +62,7 @@ impl Connection {
         #[cfg(not(feature = "msquic-2-5"))] msquic_conn: msquic::Connection,
         tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
         sslkeylog_file: Option<File>,
+        guard: RundownGuard,
     ) -> Self {
         #[cfg(feature = "msquic-2-5")]
         let msquic_conn = unsafe { msquic::Connection::from_raw(handle) };
@@ -64,7 +75,11 @@ impl Connection {
         msquic_conn.set_callback_handler(move |conn_ref, ev| {
             inner_in_ev.callback_handler_impl(conn_ref, ev)
         });
-        let instance = Arc::new(ConnectionInstance { inner, msquic_conn });
+        let instance = Arc::new(ConnectionInstance {
+            inner,
+            msquic_conn,
+            _guard: guard,
+        });
         trace!(
             "ConnectionInstance({:p}, Inner: {:p}) Open by peer",
             instance,
@@ -602,6 +617,13 @@ impl Connection {
 struct ConnectionInstance {
     inner: Arc<ConnectionInner>,
     msquic_conn: msquic::Connection,
+    // Declared last so that, on drop, `msquic_conn`'s `ConnectionClose` (which
+    // releases the native registration rundown reference) runs before this
+    // guard decrements and wakes `Registration::wait_idle` waiters.
+    //
+    // The guard lives here rather than on `Connection` because `Connection` is
+    // `Clone`: only the last `Arc<ConnectionInstance>` closes the handle.
+    _guard: RundownGuard,
 }
 
 impl Deref for ConnectionInstance {

--- a/msquic-async/src/lib.rs
+++ b/msquic-async/src/lib.rs
@@ -4,6 +4,7 @@
 mod buffer;
 mod connection;
 mod listener;
+mod registration;
 mod stream;
 mod sync;
 
@@ -21,6 +22,7 @@ pub use connection::{
     ShutdownError as ConnectionShutdownError, StartError as ConnectionStartError,
 };
 pub use listener::{ListenError, Listener};
+pub use registration::{Registration, WaitIdle};
 pub use stream::{
     ReadError, ReadStream, StartError as StreamStartError, Stream, StreamType, WriteError,
     WriteStream,

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -1,4 +1,5 @@
 use crate::connection::Connection;
+use crate::registration::{Registration, RundownGuard, RundownState};
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -18,17 +19,30 @@ use tracing::{error, info, trace};
 pub struct Listener {
     inner: Arc<ListenerInner>,
     msquic_listener: msquic::Listener,
+    // Declared last so that, on drop, `msquic_listener`'s `ListenerClose` runs
+    // first. That drops the boxed callback closure, hence the last
+    // `Arc<ListenerInner>`, hence the owned `Configuration` and any accepted
+    // but never-polled `Connection`s -- all before this guard decrements and
+    // wakes `Registration::wait_idle` waiters.
+    _guard: RundownGuard,
 }
 
 impl Listener {
     /// Create a new listener.
     pub fn new(
-        registration: &msquic::Registration,
+        registration: &Registration,
         configuration: msquic::Configuration,
     ) -> Result<Self, ListenError> {
-        let inner = Arc::new(ListenerInner::new(configuration));
+        let inner = Arc::new(ListenerInner::new(
+            configuration,
+            registration.state().clone(),
+        ));
         let inner_in_ev = inner.clone();
-        let msquic_listener = msquic::Listener::open(registration, move |_, ev| match ev {
+        // Reserve before opening: `QuicListenerOpen` acquires the registration
+        // rundown before it returns. If `open` fails, this guard drops and
+        // releases the reservation.
+        let guard = RundownGuard::new(registration.state().clone());
+        let msquic_listener = msquic::Listener::open(registration.raw(), move |_, ev| match ev {
             msquic::ListenerEvent::NewConnection { info, connection } => {
                 inner_in_ev.handle_event_new_connection(info, connection)
             }
@@ -41,6 +55,7 @@ impl Listener {
         Ok(Self {
             inner,
             msquic_listener,
+            _guard: guard,
         })
     }
 
@@ -203,6 +218,7 @@ unsafe impl Send for ListenerInnerExclusive {}
 
 struct ListenerInnerShared {
     configuration: msquic::Configuration,
+    rundown: Arc<RundownState>,
 }
 // SAFETY: `Configuration` wraps a MsQuic handle that MsQuic documents as
 // thread-safe, so it is sound to move and share across threads.
@@ -218,7 +234,7 @@ enum ListenerState {
 }
 
 impl ListenerInner {
-    fn new(configuration: msquic::Configuration) -> Self {
+    fn new(configuration: msquic::Configuration, rundown: Arc<RundownState>) -> Self {
         Self {
             exclusive: Mutex::new(ListenerInnerExclusive {
                 state: ListenerState::Open,
@@ -227,7 +243,10 @@ impl ListenerInner {
                 shutdown_complete_waiters: Vec::new(),
                 sslkeylog_file: None,
             }),
-            shared: ListenerInnerShared { configuration },
+            shared: ListenerInnerShared {
+                configuration,
+                rundown,
+            },
         }
     }
 
@@ -292,11 +311,21 @@ impl ListenerInner {
             (None, None)
         };
         connection.set_configuration(&self.shared.configuration)?;
+        // Reserved here, once the connection is about to be handed to a
+        // `Connection` that owns the handle. The earlier `?` paths never reach
+        // this point, so they cannot leak a reservation. There is no untracked
+        // window either: this callback only runs while the `Listener` itself is
+        // alive, and its own guard keeps the count above zero throughout.
+        let guard = RundownGuard::new(self.shared.rundown.clone());
         #[cfg(feature = "msquic-2-5")]
-        let new_conn =
-            Connection::from_raw(unsafe { connection.as_raw() }, tls_secrets, sslkeylog_file);
+        let new_conn = Connection::from_raw(
+            unsafe { connection.as_raw() },
+            tls_secrets,
+            sslkeylog_file,
+            guard,
+        );
         #[cfg(not(feature = "msquic-2-5"))]
-        let new_conn = Connection::from_raw(connection, tls_secrets, sslkeylog_file);
+        let new_conn = Connection::from_raw(connection, tls_secrets, sslkeylog_file, guard);
 
         exclusive.new_connections.push_back(new_conn);
         exclusive

--- a/msquic-async/src/registration.rs
+++ b/msquic-async/src/registration.rs
@@ -1,0 +1,353 @@
+#[cfg(feature = "msquic-2-5")]
+use msquic_v2_5 as msquic;
+#[cfg(feature = "msquic-seera")]
+use seera_msquic as msquic;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{fence, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use tracing::{trace, warn};
+
+/// Wakers for all outstanding [`WaitIdle`] futures.
+#[derive(Default)]
+struct Waiters {
+    next: u64,
+    map: HashMap<u64, Waker>,
+}
+
+/// Shared rundown-tracking state, owned by a [`Registration`] and cloned into
+/// every tracked handle (connections and listeners).
+#[derive(Default)]
+pub(crate) struct RundownState {
+    /// Outstanding reservations for live tracked handles (connections +
+    /// listeners). Reserved before the handle is opened and released after it
+    /// is closed, so it conservatively over-counts relative to the native
+    /// `Registration->Rundown`: `active == 0` implies the native rundown holds
+    /// no msquic-async object, never the reverse.
+    active: AtomicUsize,
+    /// Wakers for all outstanding `wait_idle` futures. Drained and woken when
+    /// `active` transitions to 0. Supports any number of concurrent waiters.
+    waiters: Mutex<Waiters>,
+}
+
+/// RAII guard that holds one unit of a [`RundownState`]'s `active` count.
+///
+/// Store it as the field declared *after* the MsQuic handle it guards so that,
+/// on drop, the handle's Close (which releases the native registration rundown
+/// reference) runs before this guard decrements and wakes waiters.
+pub(crate) struct RundownGuard {
+    state: Arc<RundownState>,
+}
+
+impl RundownGuard {
+    pub(crate) fn new(state: Arc<RundownState>) -> Self {
+        state.active.fetch_add(1, Ordering::Relaxed);
+        Self { state }
+    }
+}
+
+impl Drop for RundownGuard {
+    fn drop(&mut self) {
+        // Release so the Close that just ran (on the handle field declared
+        // before this guard) is visible to a thread that later observes
+        // `active == 0` with Acquire.
+        if self.state.active.fetch_sub(1, Ordering::Release) == 1 {
+            fence(Ordering::Acquire);
+            // Collect under the lock, wake after releasing it.
+            let woken: Vec<Waker> = {
+                let mut waiters = self.state.waiters.lock().unwrap();
+                waiters.map.drain().map(|(_, waker)| waker).collect()
+            };
+            for waker in woken {
+                waker.wake();
+            }
+        }
+    }
+}
+
+/// MsQuic `Registration` wrapper that tracks live connections and listeners, so
+/// teardown can wait for the rundown to drain before the blocking
+/// `RegistrationClose`.
+///
+/// Dropping a raw [`msquic::Registration`] blocks until every child handle has
+/// been closed. Neither `shutdown()` nor the `SHUTDOWN_COMPLETE` /
+/// `STOP_COMPLETE` events close a handle, so there is no way to observe that
+/// point from the outside. This wrapper counts every [`crate::Connection`] and
+/// [`crate::Listener`] created from it and exposes [`Registration::wait_idle`],
+/// which resolves once they are all closed.
+///
+/// The raw handle is intentionally not public: every rundown-holding handle
+/// must be created through a controlled entry point ([`crate::Connection::new`],
+/// [`crate::Listener::new`], [`Registration::open_configuration`]) so the count
+/// can never be bypassed.
+///
+/// # Teardown
+///
+/// ```no_run
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// # use msquic_async::msquic;
+/// let registration = msquic_async::Registration::new(&msquic::RegistrationConfig::default())?;
+/// let alpn = [msquic::BufferRef::from("sample")];
+/// let configuration = registration.open_configuration(&alpn, None)?;
+/// // ... use connections and listeners ...
+///
+/// registration.shutdown();
+/// registration.wait_idle().await;
+/// drop(configuration);
+/// drop(registration);
+/// # Ok(())
+/// # }
+/// ```
+pub struct Registration {
+    inner: msquic::Registration,
+    state: Arc<RundownState>,
+}
+
+impl Registration {
+    /// Open a registration and its rundown tracking state.
+    pub fn new(config: &msquic::RegistrationConfig) -> Result<Self, msquic::Status> {
+        let inner = msquic::Registration::new(config)?;
+        let registration = Self {
+            inner,
+            state: Arc::new(RundownState::default()),
+        };
+        trace!("Registration({:p}) new", registration.state);
+        Ok(registration)
+    }
+
+    /// Queue shutdown on all connections and stop all listeners.
+    ///
+    /// Non-blocking, and closes nothing: pair it with [`Registration::wait_idle`].
+    pub fn shutdown(&self) {
+        trace!("Registration({:p}) shutdown", self.state);
+        self.inner.shutdown();
+    }
+
+    /// Open a [`msquic::Configuration`] against this registration.
+    ///
+    /// Configurations are deliberately *not* tracked by [`Registration::wait_idle`].
+    /// `ConfigurationClose` only drops the application's reference, while each
+    /// connection holds its own; the native rundown reference is released when
+    /// that refcount reaches zero. A tracked configuration would therefore
+    /// report idle too early. Drop the returned `Configuration` after
+    /// `wait_idle()` resolves and before dropping the `Registration`.
+    pub fn open_configuration(
+        &self,
+        alpn: &[msquic::BufferRef],
+        settings: Option<&msquic::Settings>,
+    ) -> Result<msquic::Configuration, msquic::Status> {
+        msquic::Configuration::open(&self.inner, alpn, settings)
+    }
+
+    /// Resolves once no [`crate::Connection`] or [`crate::Listener`] created
+    /// from this registration holds its rundown.
+    ///
+    /// Call it after [`Registration::shutdown`] (and after dropping any
+    /// `Listener`); on its own it will simply stay pending, because nothing has
+    /// asked the connections to go away.
+    ///
+    /// Note that streams are not tracked: a resolved `wait_idle()` does not
+    /// imply every [`crate::Stream`] has been closed.
+    pub fn wait_idle(&self) -> WaitIdle {
+        WaitIdle {
+            state: self.state.clone(),
+            key: None,
+        }
+    }
+
+    /// Raw handle, for crate-internal constructors only.
+    pub(crate) fn raw(&self) -> &msquic::Registration {
+        &self.inner
+    }
+
+    pub(crate) fn state(&self) -> &Arc<RundownState> {
+        &self.state
+    }
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        let active = self.state.active.load(Ordering::Acquire);
+        if active != 0 {
+            warn!(
+                "Registration({:p}) dropped with {} live handle(s); RegistrationClose will block. \
+                 Call shutdown() and await wait_idle() before dropping.",
+                self.state, active
+            );
+        }
+        trace!("Registration({:p}) dropping", self.state);
+    }
+}
+
+/// Future returned by [`Registration::wait_idle`].
+///
+/// Resolves when every tracked connection and listener has released the
+/// rundown.
+pub struct WaitIdle {
+    state: Arc<RundownState>,
+    /// Slot in [`RundownState::waiters`], allocated on the first `Pending` poll.
+    key: Option<u64>,
+}
+
+impl WaitIdle {
+    fn deregister(&mut self) {
+        if let Some(key) = self.key.take() {
+            self.state.waiters.lock().unwrap().map.remove(&key);
+        }
+    }
+}
+
+impl Future for WaitIdle {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if this.state.active.load(Ordering::Acquire) == 0 {
+            this.deregister();
+            return Poll::Ready(());
+        }
+        {
+            let mut waiters = this.state.waiters.lock().unwrap();
+            match this.key {
+                Some(key) => {
+                    waiters.map.insert(key, cx.waker().clone());
+                }
+                None => {
+                    let key = waiters.next;
+                    waiters.next += 1;
+                    waiters.map.insert(key, cx.waker().clone());
+                    this.key = Some(key);
+                }
+            }
+        }
+        // Re-check after registering, to avoid a lost wakeup against a guard
+        // that drained to zero between the fast-path load and taking the lock.
+        if this.state.active.load(Ordering::Acquire) == 0 {
+            this.deregister();
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for WaitIdle {
+    fn drop(&mut self) {
+        self.deregister();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RundownGuard, RundownState, WaitIdle};
+
+    use std::future::Future;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    fn wait_idle(state: &Arc<RundownState>) -> WaitIdle {
+        WaitIdle {
+            state: state.clone(),
+            key: None,
+        }
+    }
+
+    fn poll_with(fut: &mut WaitIdle, waker: &Waker) -> Poll<()> {
+        let mut cx = Context::from_waker(waker);
+        std::pin::Pin::new(fut).poll(&mut cx)
+    }
+
+    struct FlagWaker(Arc<AtomicBool>);
+    impl Wake for FlagWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn flag_waker() -> (Waker, Arc<AtomicBool>) {
+        let flag = Arc::new(AtomicBool::new(false));
+        (Waker::from(Arc::new(FlagWaker(flag.clone()))), flag)
+    }
+
+    fn poll(fut: &mut WaitIdle) -> Poll<()> {
+        let (waker, _) = flag_waker();
+        poll_with(fut, &waker)
+    }
+
+    #[test]
+    fn idle_from_start_resolves_immediately() {
+        let state = Arc::new(RundownState::default());
+        assert_eq!(poll(&mut wait_idle(&state)), Poll::Ready(()));
+    }
+
+    #[test]
+    fn reservation_keeps_pending_until_dropped() {
+        let state = Arc::new(RundownState::default());
+        let guard = RundownGuard::new(state.clone());
+        let mut fut = wait_idle(&state);
+        assert_eq!(poll(&mut fut), Poll::Pending);
+        drop(guard);
+        assert_eq!(poll(&mut fut), Poll::Ready(()));
+    }
+
+    #[test]
+    fn guard_drop_wakes_registered_waiter() {
+        let state = Arc::new(RundownState::default());
+        let guard = RundownGuard::new(state.clone());
+        let mut fut = wait_idle(&state);
+
+        let (waker, woken) = flag_waker();
+        assert_eq!(poll_with(&mut fut, &waker), Poll::Pending);
+        assert!(!woken.load(Ordering::SeqCst));
+
+        drop(guard);
+        assert!(woken.load(Ordering::SeqCst), "waiter should be woken");
+        assert_eq!(poll(&mut fut), Poll::Ready(()));
+    }
+
+    #[test]
+    fn concurrent_waiters_all_complete() {
+        let state = Arc::new(RundownState::default());
+        let guard = RundownGuard::new(state.clone());
+        let (mut a, mut b) = (wait_idle(&state), wait_idle(&state));
+        assert_eq!(poll(&mut a), Poll::Pending);
+        assert_eq!(poll(&mut b), Poll::Pending);
+        drop(guard);
+        assert_eq!(poll(&mut a), Poll::Ready(()));
+        assert_eq!(poll(&mut b), Poll::Ready(()));
+    }
+
+    #[test]
+    fn dropped_waiter_deregisters_its_slot() {
+        let state = Arc::new(RundownState::default());
+        let guard = RundownGuard::new(state.clone());
+        let mut fut = wait_idle(&state);
+        assert_eq!(poll(&mut fut), Poll::Pending);
+        assert_eq!(state.waiters.lock().unwrap().map.len(), 1);
+        drop(fut);
+        assert_eq!(
+            state.waiters.lock().unwrap().map.len(),
+            0,
+            "slot must be removed on drop"
+        );
+        drop(guard);
+    }
+
+    #[test]
+    fn nested_reservations_need_all_released() {
+        let state = Arc::new(RundownState::default());
+        let first = RundownGuard::new(state.clone());
+        let second = RundownGuard::new(state.clone());
+        let mut fut = wait_idle(&state);
+        assert_eq!(poll(&mut fut), Poll::Pending);
+        drop(first);
+        assert_eq!(poll(&mut fut), Poll::Pending);
+        drop(second);
+        assert_eq!(poll(&mut fut), Poll::Ready(()));
+    }
+}

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -27,7 +27,7 @@ async fn test_connection_start() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -106,7 +106,7 @@ async fn test_connection_poll_shutdown() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     // let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -170,7 +170,7 @@ async fn test_connection_poll_shutdown() {
 /// Test for ['Listener::accept()']
 #[test(tokio::test)]
 async fn test_listener_accept() {
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -230,7 +230,7 @@ async fn test_listener_accept() {
 async fn test_open_outbound_stream() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -321,7 +321,7 @@ async fn test_open_outbound_stream() {
 async fn test_open_outbound_stream_exceed_limit() -> Result<(), anyhow::Error> {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -443,7 +443,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -582,7 +582,7 @@ async fn test_open_outbound_stream_exceed_limit_and_accepted() {
 async fn test_poll_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -659,7 +659,7 @@ async fn test_poll_write() {
 async fn test_write_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -734,7 +734,7 @@ async fn test_write_chunk() {
 async fn test_write_chunks() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -810,7 +810,7 @@ async fn test_poll_finish_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -886,7 +886,7 @@ async fn test_poll_abort_write() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -961,7 +961,7 @@ async fn test_poll_abort_write() {
 async fn test_poll_read() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1037,7 +1037,7 @@ async fn test_poll_read() {
 async fn test_read_chunk() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1141,7 +1141,7 @@ async fn test_read_chunk_empty_fin() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1234,7 +1234,7 @@ async fn test_read_chunk_empty_fin() {
 async fn test_read_chunk_multi_recv() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1337,7 +1337,7 @@ async fn test_poll_abort_read() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1417,7 +1417,7 @@ async fn test_get_local_addr() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -1486,7 +1486,7 @@ async fn test_get_remote_addr() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -1608,7 +1608,7 @@ async fn datagram_validation() {
     let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1687,7 +1687,7 @@ async fn datagram_validation() {
 async fn recv_datagram_after_peer_shutdown() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1757,7 +1757,7 @@ async fn recv_datagram_after_peer_shutdown() {
 async fn recv_datagram_after_local_shutdown() {
     let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
 
     let listener = new_server(
         &registration,
@@ -1828,7 +1828,7 @@ async fn recv_datagram_after_local_shutdown() {
 async fn test_poll_event_queuing() {
     use crate::EventError;
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -1910,7 +1910,7 @@ async fn test_poll_event_queuing() {
 #[cfg(feature = "msquic-seera")]
 #[test(tokio::test)]
 async fn test_poll_event_waker_notification() {
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -1992,7 +1992,7 @@ async fn test_poll_event_waker_notification() {
 async fn test_poll_event_connection_lost_on_shutdown() {
     use crate::EventError;
 
-    let registration = msquic::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
     let listener = new_server(
         &registration,
         &msquic::Settings::new().set_IdleTimeoutMs(10000),
@@ -2064,16 +2064,163 @@ async fn test_poll_event_connection_lost_on_shutdown() {
     });
 }
 
+const WAIT_IDLE_BUSY: Duration = Duration::from_millis(200);
+const WAIT_IDLE_DRAIN: Duration = Duration::from_secs(5);
+
+fn test_settings() -> msquic::Settings {
+    msquic::Settings::new().set_IdleTimeoutMs(10000)
+}
+
+/// Start a listener on an ephemeral loopback port and return it with its address.
+fn started_server(registration: &crate::Registration) -> (Listener, SocketAddr) {
+    let listener = new_server(registration, &test_settings()).unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+    (listener, server_addr)
+}
+
+async fn assert_busy(registration: &crate::Registration) {
+    assert!(
+        timeout(WAIT_IDLE_BUSY, registration.wait_idle())
+            .await
+            .is_err(),
+        "wait_idle() resolved while a tracked handle was still alive"
+    );
+}
+
+async fn assert_drains(registration: &crate::Registration) {
+    timeout(WAIT_IDLE_DRAIN, registration.wait_idle())
+        .await
+        .expect("wait_idle() did not resolve after all tracked handles were dropped");
+}
+
+/// A registration with nothing derived from it is idle immediately.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_when_empty() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    assert_drains(&registration).await;
+}
+
+/// A live `Listener` keeps `wait_idle()` pending; dropping it drains.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_listener() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let (listener, _server_addr) = started_server(&registration);
+
+    assert_busy(&registration).await;
+
+    listener.stop().await.unwrap();
+    // `stop()` completing is not enough: the handle is still open.
+    assert_busy(&registration).await;
+
+    drop(listener);
+    assert_drains(&registration).await;
+}
+
+/// A `Connection` that was never started is still tracked.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_unstarted_connection() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let conn = Connection::new(&registration).unwrap();
+
+    assert_busy(&registration).await;
+
+    drop(conn);
+    assert_drains(&registration).await;
+}
+
+/// The full loop: connect, shut down, drop everything, and confirm the
+/// registration drains. A timeout here is the `RegistrationClose` hang that
+/// `wait_idle()` exists to prevent.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_after_connection_closed() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let (listener, server_addr) = started_server(&registration);
+    let client_config = new_client_config(&registration, &test_settings()).unwrap();
+
+    let conn = Connection::new(&registration).unwrap();
+    let (server_conn, start_res) = tokio::join!(listener.accept(), async {
+        conn.start(
+            &client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await
+    });
+    let server_conn = server_conn.expect("accept");
+    start_res.expect("client start");
+
+    assert_busy(&registration).await;
+
+    registration.shutdown();
+    drop(server_conn);
+    drop(conn);
+    drop(listener);
+
+    assert_drains(&registration).await;
+
+    // Configurations are untracked, so they are dropped after wait_idle().
+    drop(client_config);
+    drop(registration);
+}
+
+/// The guard lives in the shared `ConnectionInstance`, so every clone must go
+/// before the registration drains. This is the case that `h3-msquic-async`
+/// hits, since it clones the connection into several boxed futures.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_connection_clones() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    let clone = conn.clone();
+
+    drop(conn);
+    assert_busy(&registration).await;
+
+    drop(clone);
+    assert_drains(&registration).await;
+}
+
+/// An inbound connection that was accepted by MsQuic but never popped via
+/// `accept()` is queued inside the listener, and must still be tracked.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_unaccepted_connection() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let (listener, server_addr) = started_server(&registration);
+    let client_config = new_client_config(&registration, &test_settings()).unwrap();
+
+    let conn = Connection::new(&registration).unwrap();
+    conn.start(
+        &client_config,
+        &format!("{}", server_addr.ip()),
+        server_addr.port(),
+    )
+    .await
+    .expect("client start");
+
+    // Deliberately never call `listener.accept()`.
+    registration.shutdown();
+    drop(conn);
+    assert_busy(&registration).await;
+
+    // Dropping the listener closes the queued inbound connection too.
+    drop(listener);
+    assert_drains(&registration).await;
+
+    drop(client_config);
+}
+
 #[cfg(not(windows))]
-fn new_server(
-    registration: &msquic::Registration,
-    settings: &msquic::Settings,
-) -> Result<Listener> {
+fn new_server(registration: &crate::Registration, settings: &msquic::Settings) -> Result<Listener> {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
     let alpn = [msquic::BufferRef::from("test")];
-    let configuration = msquic::Configuration::open(registration, &alpn, Some(settings)).unwrap();
+    let configuration = registration
+        .open_configuration(&alpn, Some(settings))
+        .unwrap();
 
     let cert = include_bytes!("../examples/cert.pem");
     let key = include_bytes!("../examples/key.pem");
@@ -2098,10 +2245,7 @@ fn new_server(
 }
 
 #[cfg(windows)]
-fn new_server(
-    registration: &msquic::Registration,
-    settings: &msquic::Settings,
-) -> Result<Listener> {
+fn new_server(registration: &crate::Registration, settings: &msquic::Settings) -> Result<Listener> {
     use schannel::cert_context::{CertContext, KeySpec};
     use schannel::cert_store::{CertAdd, Memory};
     use schannel::crypt_prov::{AcquireOptions, ProviderType};
@@ -2109,7 +2253,9 @@ fn new_server(
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let alpn = [msquic::BufferRef::from("test")];
-    let configuration = msquic::Configuration::open(registration, &alpn, Some(settings)).unwrap();
+    let configuration = registration
+        .open_configuration(&alpn, Some(settings))
+        .unwrap();
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let name = format!(
@@ -2156,11 +2302,13 @@ fn new_server(
 }
 
 fn new_client_config(
-    registration: &msquic::Registration,
+    registration: &crate::Registration,
     settings: &msquic::Settings,
 ) -> Result<msquic::Configuration> {
     let alpn = [msquic::BufferRef::from("test")];
-    let configuration = msquic::Configuration::open(registration, &alpn, Some(settings)).unwrap();
+    let configuration = registration
+        .open_configuration(&alpn, Some(settings))
+        .unwrap();
     let cred_config = msquic::CredentialConfig::new_client()
         .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
     configuration.load_credential(&cred_config).unwrap();


### PR DESCRIPTION
## Problem

Dropping a `msquic::Registration` calls `RegistrationClose`, which blocks in `CxPlatRundownReleaseAndWait` (`msquic/src/core/registration.c:53`) until every child handle has been closed. Today the only correct teardown rule is an unwritten one — *drop every `Listener`, every clone of every `Connection`, and every `Configuration` before the `Registration` goes out of scope* — and the failure mode is a silent hang inside `Drop`.

There is currently no way to observe the right moment:

- **`RegistrationShutdown` closes nothing.** It queues shutdown and stops listeners, but handles and their rundown references stay alive until the Rust values drop.
- **`SHUTDOWN_COMPLETE` is not close.** `handle_event_shutdown_complete()` (`connection.rs`) and `handle_event_stop_complete()` (`listener.rs`) set a state but close no handle, so anything built on those events is inherently racy.

This is aggravated by `Connection` being `Clone`: `h3-msquic-async` clones it into four boxed unfold futures plus `OpenStreams`, so "the application dropped its `Connection`" says nothing about whether `ConnectionClose` has run.

## Solution

Introduce `msquic_async::Registration`, which tracks every `Connection` and `Listener` created from it and exposes `wait_idle()`.

```rust
registration.shutdown();        // queue shutdown, stop listeners
registration.wait_idle().await; // every Connection/Listener handle is now closed
drop(configuration);            // configurations are untracked; drop them here
drop(registration);             // returns promptly
```

The count is reserved *before* the native handle is opened and released *after* it is closed, so it conservatively over-counts: `active == 0` implies the native rundown holds no msquic-async object, never the reverse.

This follows the design used by [`msquic-h3` `b4be259`](https://github.com/youyuanwu/msquic-h3/commit/b4be2599d1b18710d79dec314817555efaa73668), adapted to this crate's ownership graph. Full design notes are in `docs/registration-wait-idle-design.md`.

### Key design points

- **Guard placement.** The `RundownGuard` lives in `ConnectionInstance`, not on `Connection`, because `Connection` is `Clone` and only the last `Arc` closes the handle. In both `ConnectionInstance` and `Listener` the guard is declared *after* the handle field, so field drop order runs `*Close` first and only then decrements.
- **Configurations stay untracked.** `ConfigurationClose` only drops the application's reference while each connection holds its own; the rundown reference is released at refcount 0. A tracked configuration would report idle *too early*, which is worse than not tracking. Since `Listener` owns the configuration passed to it, only application-owned client configurations need manual ordering.
- **No `async fn` had to be de-`async`ed.** `msquic-h3` had to convert `connect` to return `impl Future` so the reservation happened at creation rather than first poll. `Connection::new` here is already synchronous, so the problem does not arise.
- **Inbound reservation placement.** Reserved after the last fallible step of the `NewConnection` callback. The listener's own guard keeps `active >= 1` for the callback's whole duration, so there is no untracked window; reserving at the top would instead introduce a drop-order bug, since `connection` is a parameter and locals drop before parameters.

### Known gap (pre-existing, documented not fixed)

`Stream` holds no reference to the connection, so it can outlive the last `Connection` clone. Streams are deliberately not tracked — they hold no registration rundown reference, so counting them would delay `wait_idle()` past the point the native rundown has already drained. A resolved `wait_idle()` therefore does **not** imply all streams are closed. The fix (having `StreamInstance` hold an `Arc<ConnectionInstance>`) is a separate change.

## Breaking changes

`msquic-async` 0.4.1 → **0.5.0**; `h3-msquic-async` 0.3.1 → 0.4.0.

| Before | After |
| --- | --- |
| `Connection::new(&msquic::Registration)` | `Connection::new(&msquic_async::Registration)` |
| `Listener::new(&msquic::Registration, config)` | `Listener::new(&msquic_async::Registration, config)` |
| `msquic::Configuration::open(&reg, alpn, settings)` | `reg.open_configuration(alpn, settings)` |

The raw registration handle is intentionally no longer reachable, so every rundown-holding handle must go through a controlled entry point and the count cannot be bypassed.

`h3-msquic-async`'s library code needs no change — it wraps an already-built `msquic_async::Connection` and never touches a registration.

Also added: a diagnostic `Drop for Registration` that logs a `tracing::warn!` when dropped with live handles, so a reintroduced hang is identifiable rather than silent.

## Testing

- 6 unit tests on `RundownState` / `RundownGuard` / `WaitIdle` (no msquic required): immediate-idle, pending-until-dropped, wake-on-guard-drop, concurrent waiters, waiter deregistration on drop, nested reservations.
- 6 integration tests against real msquic, including `test_registration_wait_idle_tracks_listener`, which asserts `wait_idle()` is **still pending after `stop()` completes** and only drains on drop — pinning down the event-is-not-close semantics at the heart of this bug.
- `cargo test --workspace`: 34 + 13 + 13 tests + 1 doctest, all passing. All 24 pre-existing tests pass with only the call-site type change; no regressions.
- `cargo clippy --workspace --all-targets` clean, and clean against the `msquic-2-5` and `msquic-seera` backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
