### PR TITLE
Track streams in the registration rundown

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,17 @@ neither `shutdown()` nor the shutdown-complete events close a handle, use
 
 ```rust
     registration.shutdown();       // queue shutdown on all connections, stop all listeners
-    registration.wait_idle().await; // every Connection/Listener handle is now closed
+    registration.wait_idle().await; // every Stream/Connection/Listener handle is now closed
     drop(configuration);           // configurations are not tracked; drop them here
     drop(registration);            // returns promptly
 ```
 
-`wait_idle()` tracks every `msquic_async::Connection` (including clones) and
-`Listener`. It does not track `Configuration`s -- `ConfigurationClose` only
-drops the application's reference while connections hold their own, so a tracked
-configuration would report idle too early. A `Listener` owns the configuration
-passed to it, so only application-owned client configurations need the manual
-`drop` above. Streams are not tracked either; see the crate docs for details.
+`wait_idle()` tracks every `msquic_async::Connection` (including clones),
+`Listener` and `Stream`. It does not track `Configuration`s --
+`ConfigurationClose` only drops the application's reference while connections
+hold their own, so a tracked configuration would report idle too early. A
+`Listener` owns the configuration passed to it, so only application-owned client
+configurations need the manual `drop` above.
 
 ## License
 

--- a/docs/registration-wait-idle-design.md
+++ b/docs/registration-wait-idle-design.md
@@ -4,6 +4,12 @@ Status: implemented
 Target crate: `msquic-async` (0.4.1 → 0.5.0, breaking)
 Prior art: [`msquic-h3` commit `b4be2599`](https://github.com/youyuanwu/msquic-h3/commit/b4be2599d1b18710d79dec314817555efaa73668)
 
+Revision history:
+
+- Streams are now tracked. §9 originally claimed a `Stream` outliving its
+  `Connection` was an unrelated, pre-existing hazard; that was wrong on both
+  counts, and it was a hole in the `wait_idle()` guarantee. See §9.
+
 ## 1. Problem
 
 Dropping a `msquic::Registration` blocks — potentially forever — unless every
@@ -58,12 +64,16 @@ application dropped its `Connection`" says nothing about whether
 
 **Goals**
 
-- Provide `Registration::wait_idle()`, an async signal that resolves once no
-  `msquic-async` connection or listener holds the registration rundown.
-- Make it structurally impossible to create an untracked connection or listener,
-  by routing every construction path through the wrapper.
+- Provide `Registration::wait_idle()`, an async signal that resolves once it is
+  safe to drop the `Registration` — i.e. once every `msquic-async` handle that
+  `RegistrationClose` could invalidate has been closed.
+- Make it structurally impossible to create an untracked connection, listener or
+  stream, by routing every construction path through the wrapper.
 - Keep the tracking free of dependencies beyond `std`, usable from any executor,
   and correct under an arbitrary number of concurrent waiters.
+
+Note the goal is deliberately *not* "resolve once the native rundown has
+drained". Those two are not the same, and §9 is exactly where they diverge.
 
 **Non-goals**
 
@@ -72,7 +82,6 @@ application dropped its `Connection`" says nothing about whether
 - Making `Registration::drop` non-blocking, or adopting `RegistrationClose2`.
   The FFI entry exists (`msquic/src/rs/ffi/linux_bindings.rs:6726`) but is
   unused by the binding; wrapping it is a separate change.
-- Fixing the `Stream`-outlives-`Connection` hazard (§9).
 
 ## 3. Design overview
 
@@ -244,6 +253,39 @@ local, and locals drop *before* parameters, so the guard would decrement before
 `ConnectionClose`. Reserving after the last `?` makes every early-return path
 trivially leak-free.
 
+### 5.4 Streams
+
+```rust
+pub(crate) struct StreamInstance {
+    inner: Arc<StreamInner>,
+    msquic_stream: msquic::Stream,
+    _guard: RundownGuard,
+}
+```
+
+`Stream`, `ReadStream` and `WriteStream` all wrap `Arc<StreamInstance>`, so one
+guard covers every alias of a stream. See §9 for why streams are tracked at all.
+
+Streams are created from two places, and neither has a `Registration` in hand:
+
+- `Stream::open` from `OpenOutboundStream::poll` (`connection.rs`), which has
+  `&ConnectionInstance`.
+- `Stream::from_raw` from `handle_event_peer_stream_started`, a method on
+  `ConnectionInner` — the *callback context*, which does not hold the
+  `ConnectionInstance`.
+
+So `Arc<RundownState>` is stored on `ConnectionInner` (not only on
+`ConnectionInstance`), and both sites reserve with
+`RundownGuard::new(rundown.clone())`. `RundownGuard` exposes `state()` so
+`Connection::from_raw`, which receives a guard rather than a `Registration`, can
+seed `ConnectionInner` from it.
+
+No cycle is created: `RundownState` is owned by the `Registration` and refers to
+nothing. This is why the guard is *not* implemented by having `StreamInstance`
+hold an `Arc<ConnectionInstance>` — `ConnectionInnerExclusive.inbound_streams`
+holds `Stream` values, so that would make unaccepted inbound streams into a
+reference cycle and leak the connection.
+
 `Connection::from_raw` gains a `guard: RundownGuard` parameter. It is
 `pub(crate)`, so this is not a public API change.
 
@@ -307,10 +349,14 @@ let config = reg.open_configuration(&alpn, Some(&settings))?;
 // ... use connections ...
 
 reg.shutdown();          // queue shutdown on all connections
-reg.wait_idle().await;   // all ConnectionClose calls have completed
+reg.wait_idle().await;   // every Stream/Connection handle is now closed
 drop(config);            // now safe
 drop(reg);               // RegistrationClose returns promptly
 ```
+
+`wait_idle()` covers streams too, so a `Stream` held past its `Connection` keeps
+it pending rather than letting the registration be dropped out from under a
+pending `StreamClose` (§9).
 
 Server:
 
@@ -325,20 +371,76 @@ drop(reg);
 The order `shutdown()` then `wait_idle()` matters: `wait_idle()` alone will hang
 if nothing has asked the connections to go away.
 
-## 9. Known gaps (pre-existing, documented not fixed)
+## 9. Why streams are tracked
 
 `Stream`, `ReadStream`, and `WriteStream` are `Arc<StreamInstance>` holding a
 `msquic::Stream` handle and **no reference at all** to the connection
 (`stream.rs:33`, `:419-421`; `Stream::open` borrows `&msquic::Connection`,
-`stream.rs:36-37`). A `Stream` can therefore outlive the last `Connection`
-clone, in which case `StreamClose` runs against an already-closed parent.
+`stream.rs:36-37`). A `Stream` can therefore outlive the last `Connection` clone.
 
-This design does not change that, and deliberately does not add a stream-level
-guard: streams do not hold a registration rundown reference, so counting them
-would delay `wait_idle()` past the point the native rundown is already drained.
-The correct fix is to have `StreamInstance` hold an `Arc<ConnectionInstance>`,
-which is a separate change. Until then `wait_idle()` resolving does **not**
-imply all streams are closed.
+An earlier revision of this document called that a hazard and left it out of
+scope. Both halves of that were wrong.
+
+### 9.1 `StreamClose` after `ConnectionClose` is fine
+
+It is an explicitly supported, upstream-tested ordering:
+
+- `QuicStreamInitialize` takes `QUIC_CONN_REF_STREAM` ("A stream depends on the
+  connection", `connection.h:252`) at `stream.c:167`, and `QuicStreamFree`
+  releases it at `stream.c:244`. `MsQuicConnectionClose` only drops
+  `QUIC_CONN_REF_HANDLE_OWNER`, so the `QUIC_CONNECTION` allocation survives
+  until the last stream is freed — it is never a use-after-free.
+- `QuicConnCloseHandle` shuts streams down but frees none of them
+  (`connection.c:477` → `QuicStreamSetShutdown`, `stream_set.c:193`). The
+  application still owns every stream handle and must close each one.
+- No deadlock either. The silent shutdown drives each stream to
+  `ClientCallbackHandler = NULL`, so `MsQuicStreamClose` takes the
+  `AlreadyShutdownComplete` fire-and-forget path (`api.c:898-911`) and never
+  reaches the `CxPlatEventWaitForever` at `api.c:934`.
+- `seera-msquic/src/test/lib/OwnershipTest.cpp:258-269`
+  (`QuicTestConnectionCloseBeforeStreamClose`) closes the connection and then
+  calls `Stream.GetID()` / `Stream.SetPriority()` before the stream's destructor
+  runs `StreamClose`.
+
+### 9.2 The real constraint is `RegistrationClose`, and it is our problem
+
+`QuicConnCloseHandle` calls `QuicConnUnregister` →
+`QuicRegistrationRundownRelease` (`connection.c:494`, `:512`). **The connection
+releases the registration rundown as soon as its handle is closed, even with
+streams still open.** `RegistrationClose` therefore does not wait for them, and
+proceeds to `QuicWorkerPoolUninitialize` → `CXPLAT_FREE(WorkerPool)`
+(`worker.c:1047-1055`); the worker pool is per-registration
+(`registration.c:199-200`).
+
+But `MsQuicStreamClose` calls `QuicConnQueueOper`, which unconditionally
+enqueues onto `Connection->Worker` with no check of `HandleClosed` or
+`ShutdownComplete` (`connection.c:726-754`). So:
+
+```rust
+let stream = conn.open_outbound_stream(..).await?;
+drop(conn);                       // ConnectionClose; rundown released
+registration.wait_idle().await;   // would resolve if streams were untracked
+drop(registration);               // RegistrationClose frees the worker pool
+drop(stream);                     // StreamClose queues onto freed memory
+```
+
+That is a genuine use-after-free. It predates `wait_idle()` — the native rundown
+never protected against it — but `wait_idle()` makes it *worse* by giving callers
+a credible signal that dropping the registration is now safe.
+
+`docs/api/RegistrationClose.md` says only that configurations and connections
+must be closed first; it does not mention streams. So this ordering requirement
+is real but undocumented upstream.
+
+### 9.3 Resolution
+
+Streams get a `RundownGuard` (§5.4). Because the guard is about "may not outlive
+`RegistrationClose`" rather than "holds the native rundown", tracking an object
+that holds no rundown reference is correct rather than contradictory — it is
+precisely the gap the native rundown fails to cover.
+
+Consequence: `wait_idle()` now stays pending until every stream is closed, and
+resolving it means dropping the `Registration` is safe.
 
 ## 10. Memory ordering
 
@@ -404,6 +506,15 @@ Integration tests against real msquic, in `tests.rs`, all shipped:
     accepted by MsQuic but never popped from `new_connections` keeps
     `wait_idle()` pending until the listener is dropped.
 
+13. `test_registration_wait_idle_tracks_stream_outliving_connection` — a locally
+    opened stream held past its connection keeps `wait_idle()` pending (§9).
+14. `test_registration_wait_idle_tracks_inbound_stream` — the same for a
+    peer-initiated stream, which is built in the connection callback.
+
+Tests 13 and 14 were verified to be genuine regressions: with the stream guard
+removed, both fail on the `assert_busy` step with "wait_idle() resolved while a
+tracked handle was still alive".
+
 Not covered: a `set_configuration` failure in the inbound path. Under the final
 placement (§5.3) that path returns before any reservation exists, so there is no
 leak to test.
@@ -425,7 +536,11 @@ leak to test.
 - [x] Add integration tests 7–12.
 - [x] Bump `msquic-async` to 0.5.0 (and `h3-msquic-async` to 0.4.0, which
       depends on the breaking version).
+- [x] Add `_guard` to `StreamInstance` (declared after `msquic_stream`) and
+      `rundown: Arc<RundownState>` to `ConnectionInner`; add the `guard`
+      parameter to `Stream::open` / `Stream::from_raw`; expose
+      `RundownGuard::state()`. Integration tests 13–14.
 
 Verified with `cargo clippy --workspace --all-targets` (clean) and
-`cargo test -p msquic-async` (34 tests + 1 doctest, all passing), plus clippy
+`cargo test -p msquic-async` (36 tests + 1 doctest, all passing), plus clippy
 runs against the `msquic-2-5` and `msquic-seera` backends.

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,5 +1,5 @@
 use crate::buffer::WriteBuffer;
-use crate::registration::{Registration, RundownGuard};
+use crate::registration::{Registration, RundownGuard, RundownState};
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
 use crate::sync::LockPoisonTolerant;
 
@@ -33,7 +33,12 @@ impl Connection {
     ///
     /// The connection is not started until `start` is called.
     pub fn new(registration: &Registration) -> Result<Self, ConnectionError> {
-        let inner = Arc::new(ConnectionInner::new(ConnectionState::Open, None, None));
+        let inner = Arc::new(ConnectionInner::new(
+            ConnectionState::Open,
+            None,
+            None,
+            registration.state().clone(),
+        ));
         let inner_in_ev = inner.clone();
         // Reserve before opening: `QuicConnRegister` acquires the registration
         // rundown during `ConnectionOpen`, so reserving first leaves no window
@@ -70,6 +75,7 @@ impl Connection {
             ConnectionState::Connected,
             tls_secrets,
             sslkeylog_file,
+            guard.state().clone(),
         ));
         let inner_in_ev = inner.clone();
         msquic_conn.set_callback_handler(move |conn_ref, ev| {
@@ -642,6 +648,9 @@ impl Drop for ConnectionInstance {
 
 struct ConnectionInner {
     exclusive: Mutex<ConnectionInnerExclusive>,
+    /// Kept here, rather than only on `ConnectionInstance`, so the callback
+    /// context can reserve for peer-initiated streams.
+    rundown: Arc<RundownState>,
 }
 
 struct ConnectionInnerExclusive {
@@ -706,8 +715,10 @@ impl ConnectionInner {
         state: ConnectionState,
         tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
         sslkeylog_file: Option<File>,
+        rundown: Arc<RundownState>,
     ) -> Self {
         Self {
+            rundown,
             exclusive: Mutex::new(ConnectionInnerExclusive {
                 state,
                 error: None,
@@ -925,7 +936,11 @@ impl ConnectionInner {
             stream_type
         );
 
-        let stream = Stream::from_raw(unsafe { stream.as_raw() }, stream_type);
+        let stream = Stream::from_raw(
+            unsafe { stream.as_raw() },
+            stream_type,
+            RundownGuard::new(self.rundown.clone()),
+        );
         if (flags & msquic::StreamOpenFlags::UNIDIRECTIONAL)
             == msquic::StreamOpenFlags::UNIDIRECTIONAL
         {
@@ -1405,7 +1420,11 @@ impl Future for OpenOutboundStream<'_> {
             }
         }
         if stream.is_none() {
-            match Stream::open(&conn.msquic_conn, stream_type.take().unwrap()) {
+            match Stream::open(
+                &conn.msquic_conn,
+                stream_type.take().unwrap(),
+                RundownGuard::new(conn.rundown.clone()),
+            ) {
                 Ok(new_stream) => {
                     *stream = Some(new_stream);
                 }

--- a/msquic-async/src/registration.rs
+++ b/msquic-async/src/registration.rs
@@ -13,21 +13,20 @@ use std::task::{Context, Poll, Waker};
 use tracing::{trace, warn};
 
 /// Wakers for all outstanding [`WaitIdle`] futures.
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct Waiters {
     next: u64,
     map: HashMap<u64, Waker>,
 }
 
 /// Shared rundown-tracking state, owned by a [`Registration`] and cloned into
-/// every tracked handle (connections and listeners).
-#[derive(Default)]
+/// every tracked handle (connections, listeners and streams).
+#[derive(Debug, Default)]
 pub(crate) struct RundownState {
-    /// Outstanding reservations for live tracked handles (connections +
-    /// listeners). Reserved before the handle is opened and released after it
-    /// is closed, so it conservatively over-counts relative to the native
-    /// `Registration->Rundown`: `active == 0` implies the native rundown holds
-    /// no msquic-async object, never the reverse.
+    /// Outstanding reservations for live tracked handles (connections,
+    /// listeners and streams). Reserved before the handle is opened and
+    /// released after it is closed, so `active == 0` implies every handle that
+    /// must outlive `RegistrationClose` has been closed.
     active: AtomicUsize,
     /// Wakers for all outstanding `wait_idle` futures. Drained and woken when
     /// `active` transitions to 0. Supports any number of concurrent waiters.
@@ -37,8 +36,9 @@ pub(crate) struct RundownState {
 /// RAII guard that holds one unit of a [`RundownState`]'s `active` count.
 ///
 /// Store it as the field declared *after* the MsQuic handle it guards so that,
-/// on drop, the handle's Close (which releases the native registration rundown
-/// reference) runs before this guard decrements and wakes waiters.
+/// on drop, the handle's Close runs before this guard decrements and wakes
+/// waiters.
+#[derive(Debug)]
 pub(crate) struct RundownGuard {
     state: Arc<RundownState>,
 }
@@ -47,6 +47,12 @@ impl RundownGuard {
     pub(crate) fn new(state: Arc<RundownState>) -> Self {
         state.active.fetch_add(1, Ordering::Relaxed);
         Self { state }
+    }
+
+    /// The state this guard belongs to, so a tracked handle can reserve for the
+    /// children it creates.
+    pub(crate) fn state(&self) -> &Arc<RundownState> {
+        &self.state
     }
 }
 
@@ -69,16 +75,16 @@ impl Drop for RundownGuard {
     }
 }
 
-/// MsQuic `Registration` wrapper that tracks live connections and listeners, so
-/// teardown can wait for the rundown to drain before the blocking
+/// MsQuic `Registration` wrapper that tracks live connections, listeners and
+/// streams, so teardown can wait for them before the blocking
 /// `RegistrationClose`.
 ///
 /// Dropping a raw [`msquic::Registration`] blocks until every child handle has
 /// been closed. Neither `shutdown()` nor the `SHUTDOWN_COMPLETE` /
 /// `STOP_COMPLETE` events close a handle, so there is no way to observe that
-/// point from the outside. This wrapper counts every [`crate::Connection`] and
-/// [`crate::Listener`] created from it and exposes [`Registration::wait_idle`],
-/// which resolves once they are all closed.
+/// point from the outside. This wrapper counts every [`crate::Connection`],
+/// [`crate::Listener`] and [`crate::Stream`] created from it and exposes
+/// [`Registration::wait_idle`], which resolves once they are all closed.
 ///
 /// The raw handle is intentionally not public: every rundown-holding handle
 /// must be created through a controlled entry point ([`crate::Connection::new`],
@@ -143,15 +149,17 @@ impl Registration {
         msquic::Configuration::open(&self.inner, alpn, settings)
     }
 
-    /// Resolves once no [`crate::Connection`] or [`crate::Listener`] created
-    /// from this registration holds its rundown.
+    /// Resolves once every [`crate::Connection`], [`crate::Listener`] and
+    /// [`crate::Stream`] created from this registration has been closed, i.e.
+    /// once it is safe to drop the `Registration`.
     ///
     /// Call it after [`Registration::shutdown`] (and after dropping any
     /// `Listener`); on its own it will simply stay pending, because nothing has
     /// asked the connections to go away.
     ///
-    /// Note that streams are not tracked: a resolved `wait_idle()` does not
-    /// imply every [`crate::Stream`] has been closed.
+    /// Streams are included even though they hold no native registration
+    /// rundown reference: `StreamClose` queues work onto the connection's
+    /// worker, and that worker pool is freed by `RegistrationClose`.
     pub fn wait_idle(&self) -> WaitIdle {
         WaitIdle {
             state: self.state.clone(),

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1,5 +1,6 @@
 use crate::buffer::{StreamRecvBuffer, WriteBuffer};
 use crate::connection::ConnectionError;
+use crate::registration::RundownGuard;
 use crate::sync::LockPoisonTolerant;
 
 #[cfg(feature = "msquic-2-5")]
@@ -36,6 +37,7 @@ impl Stream {
     pub(crate) fn open(
         msquic_conn: &msquic::Connection,
         stream_type: StreamType,
+        guard: RundownGuard,
     ) -> Result<Self, StartError> {
         let flags = if stream_type == StreamType::Unidirectional {
             msquic::StreamOpenFlags::UNIDIRECTIONAL
@@ -57,6 +59,7 @@ impl Stream {
         let instance = Arc::new(StreamInstance {
             inner,
             msquic_stream,
+            _guard: guard,
         });
         trace!(
             "StreamInstance({:p}, Inner: {:p}, HQUIC: {:p}) Open by local",
@@ -68,7 +71,11 @@ impl Stream {
         Ok(Self(instance))
     }
 
-    pub(crate) fn from_raw(handle: msquic::ffi::HQUIC, stream_type: StreamType) -> Self {
+    pub(crate) fn from_raw(
+        handle: msquic::ffi::HQUIC,
+        stream_type: StreamType,
+        guard: RundownGuard,
+    ) -> Self {
         let msquic_stream = unsafe { msquic::Stream::from_raw(handle) };
         let send_state = if stream_type == StreamType::Bidirectional {
             StreamSendState::StartComplete
@@ -89,6 +96,7 @@ impl Stream {
         let stream = Self(Arc::new(StreamInstance {
             inner,
             msquic_stream,
+            _guard: guard,
         }));
         trace!(
             "StreamInstance({:p}, Inner: {:p}, HQUIC: {:p}, id: {:?}) Start by peer",
@@ -419,6 +427,18 @@ impl WriteStream {
 pub(crate) struct StreamInstance {
     inner: Arc<StreamInner>,
     msquic_stream: msquic::Stream,
+    // Declared last so `msquic_stream`'s `StreamClose` runs before this guard
+    // decrements.
+    //
+    // Streams do not hold a native registration rundown reference -- the
+    // connection releases its own in `QuicConnUnregister` as soon as
+    // `ConnectionClose` runs, even with streams still open. But `StreamClose`
+    // queues an operation onto the connection's worker, and the worker pool is
+    // owned by the registration and freed by `RegistrationClose`. Tracking
+    // streams here keeps `Registration::wait_idle` pending until every
+    // `StreamClose` has happened, which is what makes dropping the registration
+    // afterwards safe.
+    _guard: RundownGuard,
 }
 
 impl StreamInstance {

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -2068,7 +2068,10 @@ const WAIT_IDLE_BUSY: Duration = Duration::from_millis(200);
 const WAIT_IDLE_DRAIN: Duration = Duration::from_secs(5);
 
 fn test_settings() -> msquic::Settings {
-    msquic::Settings::new().set_IdleTimeoutMs(10000)
+    msquic::Settings::new()
+        .set_IdleTimeoutMs(10000)
+        .set_PeerBidiStreamCount(1)
+        .set_PeerUnidiStreamCount(1)
 }
 
 /// Start a listener on an ephemeral loopback port and return it with its address.
@@ -2207,6 +2210,97 @@ async fn test_registration_wait_idle_tracks_unaccepted_connection() {
 
     // Dropping the listener closes the queued inbound connection too.
     drop(listener);
+    assert_drains(&registration).await;
+
+    drop(client_config);
+}
+
+/// Connect a client to `listener` and return both ends.
+async fn connected_pair(
+    registration: &crate::Registration,
+    listener: &Listener,
+    server_addr: SocketAddr,
+    client_config: &msquic::Configuration,
+) -> (Connection, Connection) {
+    let conn = Connection::new(registration).unwrap();
+    let (server_conn, start_res) = tokio::join!(listener.accept(), async {
+        conn.start(
+            client_config,
+            &format!("{}", server_addr.ip()),
+            server_addr.port(),
+        )
+        .await
+    });
+    start_res.expect("client start");
+    (conn, server_conn.expect("accept"))
+}
+
+/// A locally opened stream that outlives its connection keeps `wait_idle()`
+/// pending.
+///
+/// Streams hold no native registration rundown reference -- the connection
+/// releases its own as soon as `ConnectionClose` runs -- but `StreamClose`
+/// queues an operation onto the connection's worker, and the worker pool is
+/// freed by `RegistrationClose`. Draining before the stream is closed would
+/// therefore permit a use-after-free.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_stream_outliving_connection() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let (listener, server_addr) = started_server(&registration);
+    let client_config = new_client_config(&registration, &test_settings()).unwrap();
+    let (conn, server_conn) =
+        connected_pair(&registration, &listener, server_addr, &client_config).await;
+
+    let stream = conn
+        .open_outbound_stream(crate::StreamType::Bidirectional, false)
+        .await
+        .expect("open outbound stream");
+
+    registration.shutdown();
+    drop(server_conn);
+    drop(conn);
+    drop(listener);
+
+    assert_busy(&registration).await;
+
+    drop(stream);
+    assert_drains(&registration).await;
+
+    drop(client_config);
+}
+
+/// The same guarantee for a peer-initiated stream, which is constructed in the
+/// connection callback rather than by the application.
+#[test(tokio::test)]
+async fn test_registration_wait_idle_tracks_inbound_stream() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let (listener, server_addr) = started_server(&registration);
+    let client_config = new_client_config(&registration, &test_settings()).unwrap();
+    let (conn, server_conn) =
+        connected_pair(&registration, &listener, server_addr, &client_config).await;
+
+    let mut client_stream = conn
+        .open_outbound_stream(crate::StreamType::Bidirectional, false)
+        .await
+        .expect("open outbound stream");
+    let _ = poll_fn(|cx| client_stream.poll_write(cx, b"hello", false))
+        .await
+        .expect("write");
+
+    let server_stream = server_conn
+        .accept_inbound_stream()
+        .await
+        .expect("accept inbound stream");
+
+    registration.shutdown();
+    drop(conn);
+    drop(server_conn);
+    drop(listener);
+    drop(client_stream);
+
+    assert_busy(&registration).await;
+
+    drop(server_stream);
     assert_drains(&registration).await;
 
     drop(client_config);


### PR DESCRIPTION
Follow-up to #73.

## Problem

`wait_idle()` could resolve while a `Stream` was still open, and dropping the `Registration` at that point is a **use-after-free**.

`QuicConnCloseHandle` calls `QuicConnUnregister` → `QuicRegistrationRundownRelease` (`connection.c:494`, `:512`), so a connection releases the registration rundown as soon as its handle is closed — **even with streams still open**. `RegistrationClose` therefore does not wait for them, and goes on to `QuicWorkerPoolUninitialize` → `CXPLAT_FREE(WorkerPool)` (`worker.c:1047-1055`); the worker pool is per-registration (`registration.c:199-200`).

But `MsQuicStreamClose` queues an operation via `QuicConnQueueOper`, which enqueues onto `Connection->Worker` unconditionally, with no check of `HandleClosed` or `ShutdownComplete` (`connection.c:726-754`):

```rust
let stream = conn.open_outbound_stream(..).await?;
drop(conn);                       // ConnectionClose; rundown released
registration.wait_idle().await;   // resolved
drop(registration);               // RegistrationClose frees the worker pool
drop(stream);                     // StreamClose queues onto freed memory
```

This predates #73 — the native rundown never protected against it — but `wait_idle()` makes it worse by giving callers a credible signal that dropping the registration is now safe. `docs/api/RegistrationClose.md` mentions only configurations and connections, never streams, so the requirement is real but undocumented upstream.

## What `StreamClose`-after-`ConnectionClose` actually does

The design doc from #73 claimed this ordering was itself a hazard. **That was wrong**, and this PR corrects §9. It is an explicitly supported, upstream-tested ordering:

- `QuicStreamInitialize` takes `QUIC_CONN_REF_STREAM` ("A stream depends on the connection", `connection.h:252`) at `stream.c:167`; `QuicStreamFree` releases it at `stream.c:244`. `MsQuicConnectionClose` only drops `QUIC_CONN_REF_HANDLE_OWNER`, so the `QUIC_CONNECTION` allocation survives until the last stream is freed.
- `QuicConnCloseHandle` shuts streams down but frees none (`QuicStreamSetShutdown`, `stream_set.c:193`) — the app still owns every stream handle.
- No deadlock: the silent shutdown drives each stream to `ClientCallbackHandler = NULL`, so `MsQuicStreamClose` takes the `AlreadyShutdownComplete` fire-and-forget path (`api.c:898-911`) and never reaches `CxPlatEventWaitForever` (`api.c:934`).
- `seera-msquic/src/test/lib/OwnershipTest.cpp:258-269` (`QuicTestConnectionCloseBeforeStreamClose`) closes the connection, then calls `Stream.GetID()` / `Stream.SetPriority()` before the stream destructor runs `StreamClose`.

The real constraint is not `ConnectionClose` — it is `RegistrationClose`.

## Fix

`StreamInstance` gets a `RundownGuard`, declared after `msquic_stream` so `StreamClose` runs first. `Stream`, `ReadStream` and `WriteStream` all wrap `Arc<StreamInstance>`, so one guard covers every alias.

Neither creation site has a `Registration` in hand — `Stream::open` has `&ConnectionInstance`, and `Stream::from_raw` is called from a method on `ConnectionInner` (the callback context, which does not hold the instance). So `Arc<RundownState>` is stored on `ConnectionInner`, and `RundownGuard` gains `state()` so `Connection::from_raw` can seed it from the guard it is handed.

Deliberately **not** implemented by having `StreamInstance` hold an `Arc<ConnectionInstance>`: `ConnectionInnerExclusive.inbound_streams` holds `Stream` values, so that would turn unaccepted inbound streams into a reference cycle and leak the connection.

### A note on what a guard means

This reframes the invariant from "holds the native registration rundown" to **"must not outlive `RegistrationClose`"**. Under that reading, tracking an object that holds no rundown reference is not a contradiction — it is precisely the gap the native rundown fails to cover. #73's §9 rejected stream tracking on the old reading; the doc now states the goal explicitly so this doesn't get re-litigated.

## Testing

Two integration tests, both **verified to be genuine regressions** — with the stream guard removed they fail on `assert_busy` with "wait_idle() resolved while a tracked handle was still alive":

- `test_registration_wait_idle_tracks_stream_outliving_connection` — a locally opened stream held past its connection keeps `wait_idle()` pending.
- `test_registration_wait_idle_tracks_inbound_stream` — same for a peer-initiated stream, built in the connection callback.

`cargo test --workspace`: 36 + 13 + 13 + 1 doctest, all passing. `cargo clippy --workspace --all-targets` clean, and clean against the `msquic-2-5` and `msquic-seera` backends. `cargo fmt --all --check` clean.

Version stays at 0.5.0, which is not yet published to crates.io — this ships as part of the same unreleased version. No public API change (all additions are `pub(crate)`).

Docs updated: design doc §2/§5.4/§8/§9/§12/§13 (with a revision-history note recording the correction), plus the crate docs and the README shutdown section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
