### PR TITLE
feat(connection): expose get_stats on the async Connection

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -388,6 +388,14 @@ impl Connection {
             .map_err(ConnectionError::OtherError)
     }
 
+    /// Get connection statistics (RTT, byte counters, loss, etc.).
+    pub fn get_stats(&self) -> Result<msquic::ffi::QUIC_STATISTICS, ConnectionError> {
+        self.0
+            .msquic_conn
+            .get_stats()
+            .map_err(ConnectionError::OtherError)
+    }
+
     /// Set whether to share the UDP binding.
     pub fn set_share_binding(&self, share: bool) -> Result<(), ConnectionError> {
         let share: u8 = if share { 1 } else { 0 };


### PR DESCRIPTION
## Summary

Exposes `get_stats()` on the async `Connection`, delegating to the low-level
`msquic::Connection::get_stats()`. This lets callers read `QUIC_STATISTICS`
(RTT, byte counters, loss, etc.) without reaching into the raw handle.

```rust
pub fn get_stats(&self) -> Result<msquic::ffi::QUIC_STATISTICS, ConnectionError> {
    self.0
        .msquic_conn
        .get_stats()
        .map_err(ConnectionError::OtherError)
}
```

## Rationale

Mirrors the existing `get_local_addr` / `get_remote_addr` wrappers in shape and
error handling (`ConnectionError::OtherError`). The `msquic::` alias resolves to
whichever backend crate is selected (`msquic`, `seera-msquic`, `msquic-v2-5`),
all of which already provide the low-level `get_stats`.

Motivation: the ISEKAI-link camera client needs per-connection RTT to draw a
live latency graph.

## Scope

- Single method added; no behavior change elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
