### PR TITLE
feat(connection): add set_local_addr and set_unconnected_socket

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -388,6 +388,25 @@ impl Connection {
             .map_err(ConnectionError::OtherError)
     }
 
+    /// Set the local address of the connection.
+    ///
+    /// Only valid on a client connection. Before [`Connection::start()`] this just
+    /// records the address to bind to; afterwards it migrates the connection, which
+    /// requires the handshake to be confirmed. Calling it on a server, on a locally
+    /// closed connection, or after start but before handshake confirmation fails with
+    /// `QUIC_STATUS_INVALID_STATE`.
+    pub fn set_local_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_LOCAL_ADDRESS,
+                std::mem::size_of::<msquic::Addr>() as u32,
+                &msquic::Addr::from(addr) as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
     /// Get connection statistics (RTT, byte counters, loss, etc.).
     pub fn get_stats(&self) -> Result<msquic::ffi::QUIC_STATISTICS, ConnectionError> {
         self.0
@@ -405,6 +424,28 @@ impl Connection {
                 msquic::ffi::QUIC_PARAM_CONN_SHARE_UDP_BINDING,
                 std::mem::size_of::<u8>() as u32,
                 &share as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
+    /// Set whether to use the unconnected UDP socket.
+    ///
+    /// Must be called on a client connection before [`Connection::start()`], and only
+    /// after [`Connection::set_share_binding(true)`](Connection::set_share_binding):
+    /// an unconnected socket receives datagrams from any remote address, so the
+    /// connection has to be identifiable by its connection ID alone, which requires a
+    /// non-zero length source connection ID that only a shared binding gives it.
+    /// Otherwise this fails with `QUIC_STATUS_INVALID_STATE`.
+    #[cfg(feature = "msquic-seera")]
+    pub fn set_unconnected_socket(&self, unconnected: bool) -> Result<(), ConnectionError> {
+        let unconnected: u8 = if unconnected { 1 } else { 0 };
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET,
+                std::mem::size_of::<u8>() as u32,
+                &unconnected as *const _ as *const _,
             )
         }
         .map_err(ConnectionError::OtherError)


### PR DESCRIPTION
## Summary

Exposes two more connection-level setters on the async `Connection`, mirroring the shape of the existing `set_share_binding` / `add_path` wrappers (raw `Api::set_param` + `ConnectionError::OtherError`):

- **`set_local_addr(SocketAddr)`** → `QUIC_PARAM_CONN_LOCAL_ADDRESS`. Available on all msquic variants. Before `start()` it just records the address to bind to; after the handshake is confirmed it migrates the connection.
- **`set_unconnected_socket(bool)`** → `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET`, gated on `msquic-seera` since the parameter only exists in the SEERA fork. Must be set on a client before `start()`, and only after `set_share_binding(true)` — an unconnected socket receives datagrams from any remote address, so the connection has to be identifiable by its connection ID alone, which requires the non-zero length source connection ID that a shared binding gives it.

Both constraints are documented on the methods so misuse (`QUIC_STATUS_INVALID_STATE`) is easier to diagnose.

## Submodule bump

`seera-msquic` 5baf0cc → f433f4b, which is what introduces `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET`:

- seera#49 Add `QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET`
- seera#50 Scope the datagram send state indication to servers
- seera#47 Track the datagram send state last indicated to the application
- seera#45 Fix MSVC build with `-LoggingType stdout`
- seera#43 Fix OBSERVED_ADDRESS frame codepoints and make address discovery opt-in

## Test plan

- `cargo check -p msquic-async` on all three feature configurations (default / `tokio,msquic-2-5` / `tokio,msquic-seera`) — `set_local_addr` is not feature-gated, so all three matter
- `cargo clippy -p msquic-async --no-default-features --features tokio,msquic-seera` — clean
- `cargo fmt --check -p msquic-async` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p msquic-async` on default and `msquic-seera` features — no broken intra-doc links

🤖 Generated with [Claude Code](https://claude.com/claude-code)