### PR TITLE
chore(seera-msquic): bump to 1e309b4 for bound-address binding fix

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -515,6 +515,18 @@ impl Connection {
     }
 
     /// Add a bound address to the connection.
+    ///
+    /// A UDP socket is bound to `addr` as given, and the address is advertised to the
+    /// peer in an ADD_ADDRESS frame. Passing port 0 requests an ephemeral port, which
+    /// is read back off the binding and recorded as the advertised address. Note that
+    /// the address is bound as specified rather than on a dual-stack wildcard socket,
+    /// so an IPv4 address yields an IPv4-only socket.
+    ///
+    /// Requires server migration to have been negotiated on a client, and not to have
+    /// been negotiated on a server; on a locally closed connection, an address already
+    /// bound on this connection, or more than 128 bound addresses, this fails with
+    /// `QUIC_STATUS_INVALID_STATE`, `QUIC_STATUS_ADDRESS_IN_USE` or
+    /// `QUIC_STATUS_OUT_OF_MEMORY` respectively.
     #[cfg(feature = "msquic-seera")]
     pub fn add_bound_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
         unsafe {


### PR DESCRIPTION
## Summary

Bumps the `seera-msquic` submodule f433f4b → 1e309b4 (one commit: seera#51 *"Bind a bound address on the address that was named"*), and documents the resulting behaviour on `Connection::add_bound_addr()`.

## What changed in the submodule

`QuicConnAddBoundAddress` in `src/core/connection.c` (+7 / -11). Previously the UDP binding was always created on the IPv6 wildcard with only the caller's port carried over:

```c
QUIC_ADDR BindingLocalAddress = {0};
QuicAddrSetFamily(&BindingLocalAddress, QUIC_ADDRESS_FAMILY_INET6);
QuicAddrSetPort(&BindingLocalAddress, PortUnspecified ? 0 : QuicAddrGetPort(Param));
UdpConfig.LocalAddress = &BindingLocalAddress;
```

So the socket listened on every local address, and the address recorded in `Bound->Address` — the one advertised to the peer in ADD_ADDRESS — was not the address actually bound. On a multi-homed host an application could not choose which interface a bound address belonged to. The caller's `QUIC_ADDR` is now passed through as given (`UdpConfig.LocalAddress = Param`); a zero port still requests an ephemeral one and is still read back off the binding afterwards. Two comments describing the old behaviour were updated to match.

## Impact on msquic-async

No API or FFI surface changed, so no code needed updating. The runtime behaviour of `Connection::add_bound_addr()` does change: the address passed in is now the address actually bound — which is the point of the parameter on a multi-homed host — but it also means an IPv4 address no longer ends up on a dual-stack wildcard socket.

The second commit documents that on `add_bound_addr()`, along with the preconditions the core enforces (server migration negotiated on a client / not negotiated on a server, not locally closed, address not already bound, at most `QUIC_MAX_LOCAL_ADDRESS_COUNT` = 128 bound addresses) so the returned status codes are easier to map back to a cause.

## Test plan

- `cargo check -p msquic-async --no-default-features --features tokio,msquic-seera` — clean
- `cargo fmt --check -p msquic-async` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p msquic-async --no-default-features --features tokio,msquic-seera` — no warnings or broken intra-doc links
- Docs-only on the Rust side; the submodule change is covered by the existing bound-address tests upstream (which pass either way, since they use loopback where the wildcard binding also receives the traffic — the difference shows on a multi-homed host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)