### PR TITLE
chore(seera-msquic): bump to fc4661f for unconnected sockets on added paths

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -437,6 +437,16 @@ impl Connection {
     /// connection has to be identifiable by its connection ID alone, which requires a
     /// non-zero length source connection ID that only a shared binding gives it.
     /// Otherwise this fails with `QUIC_STATUS_INVALID_STATE`.
+    ///
+    /// It also requires a specific local address, set with
+    /// [`Connection::set_local_addr()`](Connection::set_local_addr). A connected socket
+    /// takes its source address from the kernel when it is connected; an unconnected one
+    /// does not, and the connection's first packet goes out before anything has been
+    /// learned from the peer, so the address to send from has to be named. Starting a
+    /// connection with no local address, or a wildcard one (`0.0.0.0` / `::`), fails with
+    /// `QUIC_STATUS_INVALID_PARAMETER`; the port may be left as 0 to let the stack choose
+    /// one. The same requirement applies to every path added with
+    /// [`Connection::add_path()`](Connection::add_path).
     #[cfg(feature = "msquic-seera")]
     pub fn set_unconnected_socket(&self, unconnected: bool) -> Result<(), ConnectionError> {
         let unconnected: u8 = if unconnected { 1 } else { 0 };
@@ -452,6 +462,21 @@ impl Connection {
     }
 
     /// Add a new path to the connection.
+    ///
+    /// When the connection was configured with
+    /// [`Connection::set_unconnected_socket(true)`](Connection::set_unconnected_socket),
+    /// `local_addr` has to name a specific address for the same reason the connection's
+    /// own local address does: an unconnected socket has no source address of its own,
+    /// and the path's first packet goes out before anything has been learned from the
+    /// peer. A wildcard address (`0.0.0.0` / `::`) fails with
+    /// `QUIC_STATUS_INVALID_PARAMETER`; the port may be left as 0 to let the stack choose
+    /// one. Given a specific address, the path shares the connection's binding — and so
+    /// its local port — rather than opening one of its own.
+    ///
+    /// The address is checked when the path's UDP binding is opened, which happens here
+    /// once the handshake has completed, and otherwise on handshake completion. A path
+    /// added before [`Connection::start()`] becomes the connection's first path, whose
+    /// address `start()` itself checks.
     #[cfg(feature = "msquic-seera")]
     pub fn add_path(
         &self,


### PR DESCRIPTION
## Summary

Bumps the `seera-msquic` submodule `0c7ea12` → `fc4661f` (one commit: [`Apply the unconnected socket requirements to added paths (#63)`](https://github.com/seera-networks/msquic/commit/fc4661fc0e18ab1e0efff2be344ed0a6f009a7e2)). No API or FFI surface changed, so nothing on the Rust side needed updating, but the status code one error case reports does change — see below.

## What changed in the submodule

`QUIC_PARAM_CONN_UNCONNECTED_UDP_SOCKET` was only honoured on the connection's first path. `QuicConnOpenNewPath`, which opens the binding for every path added afterwards through `QUIC_PARAM_CONN_ADD_PATH`, still passed the path's remote address to `QuicLibraryGetBinding`, so the added path got a connected socket and a binding of its own — a connection using the parameter to keep several destinations on one local port silently picked up a second local port as soon as it added a path.

`UdpConfig.RemoteAddress` is now left `NULL` when the parameter is set, which is what marks the binding unconnected and lets the lookup match on local port alone:

```c
if (Connection->State.UnconnectedSocket) {
    UdpConfig.RemoteAddress = NULL;
} else if (QuicAddrIsWildCard(...)) {
    ...
```

The two requirements `QuicConnStart` already enforced are now enforced in `QuicConnOpenNewPath` as well, before the binding is built: a shared binding (`QUIC_STATUS_INVALID_STATE`) and a specific, non-wildcard local address (`QUIC_STATUS_INVALID_PARAMETER`). The early `goto Error` is safe — the label only releases `PathID`, which is `NULL` at that point.

## Impact on msquic-async

`Connection::add_path()` now rejects a wildcard local address with `QUIC_STATUS_INVALID_PARAMETER` when the connection was configured with `Connection::set_unconnected_socket(true)`, instead of quietly opening a separate connected binding for that path. Callers that pass a specific local address — the only way the parameter was meant to be used — see no change beyond the added path now sharing the local port as intended.

The same requirement checked by `QuicConnStart` also changed its status code from `QUIC_STATUS_INVALID_STATE` to `QUIC_STATUS_INVALID_PARAMETER`, since it describes an address the caller passed in rather than a state the connection is in. No rustdoc named that code for this case, so no documentation went stale; `set_unconnected_socket()`'s documented `QUIC_STATUS_INVALID_STATE` is the share-binding requirement, which is unchanged.

## Test plan

- `cargo check --workspace --all-targets --locked` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
