### PR TITLE
fix(waker): register a waiting task once per list instead of once per poll

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::buffer::WriteBuffer;
 use crate::registration::{Registration, RundownGuard, RundownState};
 use crate::stream::{ReadStream, StartError as StreamStartError, Stream, StreamType};
-use crate::sync::LockPoisonTolerant;
+use crate::sync::{register_waker, LockPoisonTolerant};
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -134,7 +134,7 @@ impl Connection {
                 )));
             }
         }
-        exclusive.start_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.start_waiters, cx);
         Poll::Pending
     }
 
@@ -168,7 +168,7 @@ impl Connection {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {}
@@ -182,7 +182,7 @@ impl Connection {
         if !exclusive.inbound_streams.is_empty() {
             return Poll::Ready(Ok(exclusive.inbound_streams.pop_front().unwrap()));
         }
-        exclusive.inbound_stream_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.inbound_stream_waiters, cx);
         Poll::Pending
     }
 
@@ -202,7 +202,7 @@ impl Connection {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {}
@@ -216,9 +216,7 @@ impl Connection {
         if !exclusive.inbound_uni_streams.is_empty() {
             return Poll::Ready(Ok(exclusive.inbound_uni_streams.pop_front().unwrap()));
         }
-        exclusive
-            .inbound_uni_stream_waiters
-            .push(cx.waker().clone());
+        register_waker(&mut exclusive.inbound_uni_stream_waiters, cx);
         Poll::Pending
     }
 
@@ -233,7 +231,7 @@ impl Connection {
                 return Poll::Ready(Err(DgramReceiveError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {}
@@ -247,7 +245,7 @@ impl Connection {
         if let Some(buf) = exclusive.recv_buffers.pop_front() {
             Poll::Ready(Ok(buf))
         } else {
-            exclusive.recv_waiters.push(cx.waker().clone());
+            register_waker(&mut exclusive.recv_waiters, cx);
             Poll::Pending
         }
     }
@@ -264,7 +262,7 @@ impl Connection {
                 return Poll::Ready(Err(DgramSendError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {}
@@ -325,7 +323,7 @@ impl Connection {
                 return Poll::Ready(Err(ShutdownError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {
@@ -347,7 +345,7 @@ impl Connection {
             }
         }
 
-        exclusive.shutdown_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.shutdown_waiters, cx);
         Poll::Pending
     }
 
@@ -650,7 +648,7 @@ impl Connection {
                 return Poll::Ready(Err(EventError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected | ConnectionState::Shutdown => {}
@@ -662,7 +660,7 @@ impl Connection {
         }
 
         if exclusive.events.is_empty() {
-            exclusive.event_waiters.push(cx.waker().clone());
+            register_waker(&mut exclusive.event_waiters, cx);
             Poll::Pending
         } else {
             Poll::Ready(Ok(exclusive.events.pop_front().unwrap()))
@@ -1495,7 +1493,7 @@ impl Future for OpenOutboundStream<'_> {
                 return Poll::Ready(Err(StreamStartError::ConnectionNotStarted));
             }
             ConnectionState::Connecting => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             ConnectionState::Connected => {}

--- a/msquic-async/src/listener.rs
+++ b/msquic-async/src/listener.rs
@@ -1,5 +1,6 @@
 use crate::connection::Connection;
 use crate::registration::{Registration, RundownGuard, RundownState};
+use crate::sync::register_waker;
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -128,7 +129,7 @@ impl Listener {
                 return Poll::Ready(Err(ListenError::Finished));
             }
         }
-        exclusive.new_connection_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.new_connection_waiters, cx);
         Poll::Pending
     }
 
@@ -157,7 +158,7 @@ impl Listener {
                     return Poll::Ready(Ok(()));
                 }
             }
-            exclusive.shutdown_complete_waiters.push(cx.waker().clone());
+            register_waker(&mut exclusive.shutdown_complete_waiters, cx);
         }
         if call_stop {
             self.msquic_listener.stop();
@@ -179,6 +180,16 @@ impl Listener {
             .get_local_addr()
             .map(|addr| addr.port())
             .map_err(|_| ListenError::Failed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_connection_waiter_count(&self) -> usize {
+        self.inner
+            .exclusive
+            .lock()
+            .unwrap()
+            .new_connection_waiters
+            .len()
     }
 
     /// Set the SSL key log file for new connections.

--- a/msquic-async/src/stream.rs
+++ b/msquic-async/src/stream.rs
@@ -1,7 +1,7 @@
 use crate::buffer::{StreamRecvBuffer, WriteBuffer};
 use crate::connection::ConnectionError;
 use crate::registration::RundownGuard;
-use crate::sync::LockPoisonTolerant;
+use crate::sync::{register_waker, LockPoisonTolerant};
 
 #[cfg(feature = "msquic-2-5")]
 use msquic_v2_5 as msquic;
@@ -169,7 +169,7 @@ impl Stream {
                 }
             }
         }
-        exclusive.start_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.start_waiters, cx);
         Poll::Pending
     }
 
@@ -579,7 +579,7 @@ impl StreamInstance {
                     return Poll::Ready(Err(ReadError::Closed));
                 }
                 StreamRecvState::Start => {
-                    exclusive.start_waiters.push(cx.waker().clone());
+                    register_waker(&mut exclusive.start_waiters, cx);
                     return Poll::Pending;
                 }
                 StreamRecvState::StartComplete => {}
@@ -608,7 +608,7 @@ impl StreamInstance {
                     Poll::Ready(Ok(read))
                 }
                 ReadStatus::Blocked(None) => {
-                    exclusive.read_waiters.push(cx.waker().clone());
+                    register_waker(&mut exclusive.read_waiters, cx);
                     Poll::Pending
                 }
             };
@@ -761,7 +761,7 @@ impl StreamInstance {
         let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::Start => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             StreamSendState::StartComplete => {
@@ -790,7 +790,7 @@ impl StreamInstance {
                 return Poll::Ready(Err(WriteError::Closed));
             }
         }
-        exclusive.write_shutdown_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.write_shutdown_waiters, cx);
         Poll::Pending
     }
 
@@ -802,7 +802,7 @@ impl StreamInstance {
         let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.send_state {
             StreamSendState::Start => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 return Poll::Pending;
             }
             StreamSendState::StartComplete => {
@@ -831,7 +831,7 @@ impl StreamInstance {
                 return Poll::Ready(Err(WriteError::Closed));
             }
         }
-        exclusive.write_shutdown_waiters.push(cx.waker().clone());
+        register_waker(&mut exclusive.write_shutdown_waiters, cx);
         Poll::Pending
     }
 
@@ -857,7 +857,7 @@ impl StreamInstance {
         let mut exclusive = self.inner.exclusive.lock_poison_tolerant();
         match exclusive.recv_state {
             StreamRecvState::Start => {
-                exclusive.start_waiters.push(cx.waker().clone());
+                register_waker(&mut exclusive.start_waiters, cx);
                 Poll::Pending
             }
             StreamRecvState::StartComplete => {

--- a/msquic-async/src/sync.rs
+++ b/msquic-async/src/sync.rs
@@ -1,4 +1,5 @@
 use std::sync::{Mutex, MutexGuard};
+use std::task::{Context, Waker};
 
 /// Extension trait for locking a [`Mutex`] while tolerating poisoning.
 ///
@@ -15,5 +16,60 @@ pub(crate) trait LockPoisonTolerant<T> {
 impl<T> LockPoisonTolerant<T> for Mutex<T> {
     fn lock_poison_tolerant(&self) -> MutexGuard<'_, T> {
         self.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Record `cx`'s waker in `waiters`, unless one already there wakes the same task.
+///
+/// The futures in this crate carry no registration of their own, so a waker put
+/// on one of these lists is only removed when the list is drained to wake it.
+/// Polling therefore has to be idempotent: `tokio::select!` drops and rebuilds
+/// its branch futures on every iteration, and re-polls all of them whenever the
+/// task wakes for whichever branch became ready, so pushing unconditionally
+/// would grow the list without bound for as long as the awaited event does not
+/// arrive.
+///
+/// Registering the task once is enough. Waking it re-polls whatever future it
+/// holds at that point, which registers again if it is still waiting, so the
+/// list holds one entry per distinct waiting task rather than one per poll.
+/// `select!` polls its branches with the caller's own [`Context`] rather than a
+/// per-branch waker, so its repeated polls do collapse onto a single entry.
+pub(crate) fn register_waker(waiters: &mut Vec<Waker>, cx: &Context<'_>) {
+    if !waiters.iter().any(|waiter| waiter.will_wake(cx.waker())) {
+        waiters.push(cx.waker().clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::task::Wake;
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    #[test]
+    fn register_waker_keeps_one_entry_per_task() {
+        let task_a = Waker::from(Arc::new(NoopWake));
+        let task_b = Waker::from(Arc::new(NoopWake));
+        let mut waiters = Vec::new();
+
+        for _ in 0..8 {
+            register_waker(&mut waiters, &Context::from_waker(&task_a));
+        }
+        assert_eq!(waiters.len(), 1, "re-polling one task registers it once");
+
+        register_waker(&mut waiters, &Context::from_waker(&task_b));
+        assert_eq!(waiters.len(), 2, "another task registers separately");
+
+        // Waking drains the list, and whoever is still waiting registers again.
+        waiters.clear();
+        register_waker(&mut waiters, &Context::from_waker(&task_a));
+        assert_eq!(waiters.len(), 1);
     }
 }

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -225,6 +225,42 @@ async fn test_listener_accept() {
     });
 }
 
+/// Test for ['Listener::accept()'] not accumulating wakers.
+///
+/// A `select!` loop drops and rebuilds the `Accept` future on every iteration,
+/// so a registration that is only ever removed by a wake-up would grow the
+/// waiter list without bound while no connection arrives.
+#[test(tokio::test)]
+async fn test_listener_accept_waker_not_accumulated() {
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+
+    // No client ever connects, so `accept()` stays pending and the other branch
+    // wins every time - the shape a `select!` loop takes while it is also
+    // serving something else.
+    for _ in 0..64 {
+        tokio::select! {
+            biased;
+            _ = listener.accept() => panic!("no connection was made"),
+            _ = tokio::time::sleep(Duration::from_millis(1)) => {}
+        }
+    }
+
+    assert_eq!(
+        listener.new_connection_waiter_count(),
+        1,
+        "one waiting task should hold one registration"
+    );
+}
+
 /// Test for ['Connection::open_outbound_stream()']
 #[test(tokio::test)]
 async fn test_open_outbound_stream() {


### PR DESCRIPTION
## Summary

The futures in this crate carry no registration of their own: every `poll_*` pushed `cx.waker()` onto a waiter list, and the only thing that ever removed an entry was a wake-up draining the whole list.

For a plain `accept().await` that is fine — the future is polled once and the entry is consumed by the event that resolves it. Under `tokio::select!` it is not. The loop drops and rebuilds its branch futures on every iteration, and re-polls all of them each time the task wakes for whichever branch became ready, so every iteration left wakers behind for as long as the awaited event did not arrive.

`Listener::accept()` in a `select!` loop was the reported case. The new test measures **128 entries in `new_connection_waiters` after 64 iterations** — two per iteration, because `select!` re-polls every branch when the task wakes for the one that is ready.

## Change

Add `sync::register_waker`, which skips the push when a stored waker already wakes the same task:

```rust
pub(crate) fn register_waker(waiters: &mut Vec<Waker>, cx: &Context<'_>) {
    if !waiters.iter().any(|waiter| waiter.will_wake(cx.waker())) {
        waiters.push(cx.waker().clone());
    }
}
```

and route all 23 registration sites through it — 2 in `listener.rs`, 13 in `connection.rs`, 8 in `stream.rs`. Waking a task re-polls whatever future it holds at that point, which registers again if it is still waiting, so one entry per waiting task is all a wake-up needs. The lists now hold one entry per distinct task rather than one per poll.

Two properties make the collapse safe and effective:

- Every one of the 32 drain sites takes the whole list with `drain(..)` and wakes each entry. No caller pops or indexes a single waiter, so an entry never has to stand for one specific future — which is what lets several futures in one task share a registration.
- `tokio::select!` polls its branches with the caller's own `Context` (tokio 1.52.3 `macros/select.rs:705`) rather than a per-branch waker, so the repeated polls of a `select!` loop really do land on one entry.

## Test plan

- `cargo test -p msquic-async --lib` — 38 passed, including:
  - `test_listener_accept_waker_not_accumulated` — drives a `select!` loop against a listener no one connects to; fails with 128 wakers before this change
  - `register_waker_keeps_one_entry_per_task` — the helper's own semantics
- `cargo check -p msquic-async --all-targets` for `msquic-latest`, `msquic-2-5` and `msquic-seera` — clean
- `cargo clippy --workspace --all-targets --locked` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
