### PR TITLE
feat(connection): let a client name its remote address before start

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -405,6 +405,29 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
+    /// Set the remote address of the connection.
+    ///
+    /// Only valid on a client connection, before [`Connection::start()`]. Setting it
+    /// makes `start`'s host argument a *name* only: msquic skips resolving it and
+    /// still uses it for SNI and certificate validation. That matters because msquic
+    /// resolves the name with a blocking `getaddrinfo` on the connection's worker
+    /// thread, which stalls every other connection on that worker for as long as the
+    /// resolver takes — so a caller that already knows the address should say so.
+    ///
+    /// A wildcard address, a server connection, or a call after start fails with
+    /// `QUIC_STATUS_INVALID_PARAMETER` / `QUIC_STATUS_INVALID_STATE`.
+    pub fn set_remote_addr(&self, addr: SocketAddr) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_REMOTE_ADDRESS,
+                std::mem::size_of::<msquic::Addr>() as u32,
+                &msquic::Addr::from(addr) as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
     /// Get connection statistics (RTT, byte counters, loss, etc.).
     pub fn get_stats(&self) -> Result<msquic::ffi::QUIC_STATISTICS, ConnectionError> {
         self.0

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -225,6 +225,63 @@ async fn test_listener_accept() {
     });
 }
 
+/// Test for ['Connection::set_remote_addr()'].
+///
+/// The host handed to `start()` is a name that cannot resolve, so the connection
+/// can only be made if msquic skipped resolution and dialed the address that was
+/// named instead. The same start is attempted first without the address, to show
+/// that the name really is unresolvable here rather than the test passing
+/// vacuously.
+#[test(tokio::test)]
+async fn test_connection_set_remote_addr() {
+    // RFC 6761 reserves `.invalid` precisely so that it never resolves.
+    const UNRESOLVABLE: &str = "unresolvable.invalid";
+
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let client_config = new_client_config(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+
+    let unresolved = Connection::new(&registration).unwrap();
+    let res = unresolved
+        .start(&client_config, UNRESOLVABLE, server_addr.port())
+        .await;
+    assert!(
+        res.is_err(),
+        "{UNRESOLVABLE} has to be unresolvable for this test to mean anything"
+    );
+
+    // Accept alongside the start: the listener and the connection it hands back
+    // have to stay alive for the handshake the client is waiting on. The timeout
+    // is what a regression trips over — a client that never gets past resolution
+    // leaves `accept()` waiting for a peer that will never arrive.
+    let conn = Connection::new(&registration).unwrap();
+    conn.set_remote_addr(server_addr).expect("set_remote_addr");
+    let (started, accepted) = timeout(Duration::from_secs(10), async {
+        tokio::join!(
+            conn.start(&client_config, UNRESOLVABLE, server_addr.port()),
+            listener.accept(),
+        )
+    })
+    .await
+    .expect("no connection was made before the timeout");
+    started.expect("start with the remote address already named");
+    accepted.expect("accept");
+}
+
 /// Test for ['Listener::accept()'] not accumulating wakers.
 ///
 /// A `select!` loop drops and rebuilds the `Accept` future on every iteration,


### PR DESCRIPTION
## Summary

Ports [`ded432c`](https://github.com/masa-koz/msquic-async-rs/commit/ded432cb699f1201d7b781db811e4a04b462ef7b) from `masa-koz/qmux-01-fix-h3-datagram` to `main`, unchanged — a `Connection::set_remote_addr()` wrapper over `QUIC_PARAM_CONN_REMOTE_ADDRESS`, mirroring the existing `set_local_addr()` — and adds the test it came without.

msquic resolves `ConnectionStart`'s host with a blocking `getaddrinfo` on the connection's worker thread. Workers are shared, so every other connection on that worker stops being serviced — its timers included — for as long as the resolver takes. A caller dialing an address it already knows should not have to pay that, and a caller with a *slow* name should not be able to idle-timeout its neighbours. Setting the remote address before start marks `RemoteAddressSet`, which skips resolution entirely while leaving the host argument to do SNI and certificate validation.

## Verified against the vendored core

Checked in `msquic/src/core` at the submodule commit `main` currently pins (`c227199`):

- `QuicConnStart` guards the resolver with `if (!Connection->State.RemoteAddressSet)` and only then calls `CxPlatDataPathResolveAddress` — so the parameter really does skip it.
- `Connection->RemoteServerName = ServerName` is assigned outside that branch, so the host argument still serves SNI and certificate validation.
- `CxPlatDataPathResolveAddress` is `getaddrinfo` (`src/platform/datapath_unix.c:128`), i.e. blocking.
- The documented failure codes match `QuicConnParamSet` (`src/core/connection.c:6494`): `QUIC_CONN_BAD_START_STATE` (started or locally closed) → `QUIC_STATUS_INVALID_STATE`; wrong length, wildcard address, or a server connection → `QUIC_STATUS_INVALID_PARAMETER`.

## Test

`test_connection_set_remote_addr` starts a client against `unresolvable.invalid` — RFC 6761 reserves `.invalid` so that it never resolves — after naming the server's address with `set_remote_addr`. The connection can only be made if msquic skipped resolution and dialed the address instead, which is the whole point of the parameter.

The same start is attempted first *without* the address and asserted to fail, so that a resolver which somehow answers for the name (a wildcard DNS provider, say) makes the test fail rather than pass vacuously.

Two details the test had to get right, both found by running it:

- The accept runs alongside the start rather than in a spawned task that ends on the first connection. Dropping the listener there also drops the connection it just returned, and the client's handshake then dies with `QUIC_STATUS_UNREACHABLE`.
- The pair is wrapped in a timeout, because that is what a regression actually trips over: a client that never gets past resolution leaves `accept()` waiting for a peer that will never arrive, so without it the test would hang instead of fail. Verified by deleting the `set_remote_addr` call — the test then fails on the timeout in 10s.

## Test plan

The parameter is not backend-specific and needs no `cfg` gating — `cargo check -p msquic-async --all-targets` passes for `msquic-latest`, `msquic-2-5` and `msquic-seera`.

- `cargo test -p msquic-async --lib` — 39 passed
- `cargo clippy --workspace --all-targets --locked` — clean
- `cargo fmt --check` — clean
- `cargo doc --no-deps -p msquic-async` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
