### PR TITLE
feat(connection): surface the multipath path events and set_path_status

### DIFF
--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -560,6 +560,36 @@ impl Connection {
         .map_err(ConnectionError::OtherError)
     }
 
+    /// Declare a path available or backup to the peer.
+    ///
+    /// `path_id` is the one carried by [`ConnectionEvent::PathAdded`]. Marking a path
+    /// active sends a PATH_AVAILABLE frame, marking it inactive a PATH_BACKUP one; a
+    /// call that does not change the status sends nothing.
+    ///
+    /// Requires multipath to have been negotiated, and fails with
+    /// `QUIC_STATUS_INVALID_STATE` otherwise. An unknown `path_id` — one never seen, or
+    /// belonging to a path since removed — fails with `QUIC_STATUS_INVALID_PARAMETER`.
+    ///
+    /// There is no counterpart for reading the status back: `QUIC_PARAM_CONN_PATH_STATUS`
+    /// is set-only in the core, which answers a get with `QUIC_STATUS_INVALID_PARAMETER`.
+    /// Track it from what this call sets and from [`ConnectionEvent::PathStatusChanged`],
+    /// which reports the peer's declarations about a path.
+    #[cfg(feature = "msquic-seera")]
+    pub fn set_path_status(&self, path_id: u32, active: bool) -> Result<(), ConnectionError> {
+        unsafe {
+            msquic::Api::set_param(
+                self.0.msquic_conn.as_raw(),
+                msquic::ffi::QUIC_PARAM_CONN_PATH_STATUS,
+                std::mem::size_of::<msquic::ffi::QUIC_PATH_STATUS>() as u32,
+                &msquic::ffi::QUIC_PATH_STATUS {
+                    PathId: path_id,
+                    Active: if active { 1 } else { 0 },
+                } as *const _ as *const _,
+            )
+        }
+        .map_err(ConnectionError::OtherError)
+    }
+
     /// Add a bound address to the connection.
     ///
     /// A UDP socket is bound to `addr` as given, and the address is advertised to the
@@ -1276,6 +1306,107 @@ impl ConnectionInner {
         Ok(())
     }
 
+    /// Queue one of the three multipath path events, which carry the same
+    /// addresses and differ only in what they say about the path.
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_path(
+        &self,
+        name: &str,
+        local_address: &msquic::Addr,
+        peer_address: &msquic::Addr,
+        path_id: u32,
+        make_event: impl FnOnce(SocketAddr, SocketAddr) -> ConnectionEvent,
+    ) -> Result<(), msquic::Status> {
+        let (Some(local_address), Some(peer_address)) =
+            (local_address.as_socket(), peer_address.as_socket())
+        else {
+            error!(
+                "ConnectionInner({:p}) {} with non-socket address",
+                self, name
+            );
+            return Ok(());
+        };
+        trace!(
+            "ConnectionInner({:p}) {} path_id:{} local_address:{} peer_address:{}",
+            self,
+            name,
+            path_id,
+            local_address,
+            peer_address
+        );
+        let mut exclusive = self.exclusive.lock_poison_tolerant();
+        exclusive
+            .events
+            .push_back(make_event(local_address, peer_address));
+        exclusive
+            .event_waiters
+            .drain(..)
+            .for_each(|waker| waker.wake());
+        Ok(())
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_path_added(
+        &self,
+        local_address: &msquic::Addr,
+        peer_address: &msquic::Addr,
+        path_id: u32,
+    ) -> Result<(), msquic::Status> {
+        self.handle_event_path(
+            "path added",
+            local_address,
+            peer_address,
+            path_id,
+            |local_address, peer_address| ConnectionEvent::PathAdded {
+                local_address,
+                peer_address,
+                path_id,
+            },
+        )
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_path_removed(
+        &self,
+        local_address: &msquic::Addr,
+        peer_address: &msquic::Addr,
+        path_id: u32,
+    ) -> Result<(), msquic::Status> {
+        self.handle_event_path(
+            "path removed",
+            local_address,
+            peer_address,
+            path_id,
+            |local_address, peer_address| ConnectionEvent::PathRemoved {
+                local_address,
+                peer_address,
+                path_id,
+            },
+        )
+    }
+
+    #[cfg(feature = "msquic-seera")]
+    fn handle_event_path_status_changed(
+        &self,
+        local_address: &msquic::Addr,
+        peer_address: &msquic::Addr,
+        path_id: u32,
+        is_active: bool,
+    ) -> Result<(), msquic::Status> {
+        self.handle_event_path(
+            "path status changed",
+            local_address,
+            peer_address,
+            path_id,
+            |local_address, peer_address| ConnectionEvent::PathStatusChanged {
+                local_address,
+                peer_address,
+                path_id,
+                is_active,
+            },
+        )
+    }
+
     fn callback_handler_impl(
         &self,
         connection: msquic::ConnectionRef,
@@ -1354,6 +1485,30 @@ impl ConnectionInner {
             msquic::ConnectionEvent::NotifyRemoteAddressRemoved { sequence_number } => {
                 self.handle_event_notify_remote_address_removed(sequence_number)
             }
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::PathAdded {
+                peer_address,
+                local_address,
+                path_id,
+            } => self.handle_event_path_added(local_address, peer_address, path_id),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::PathRemoved {
+                peer_address,
+                local_address,
+                path_id,
+            } => self.handle_event_path_removed(local_address, peer_address, path_id),
+            #[cfg(feature = "msquic-seera")]
+            msquic::ConnectionEvent::PathStatusChanged {
+                peer_address,
+                local_address,
+                path_id,
+                is_active,
+            } => self.handle_event_path_status_changed(
+                local_address,
+                peer_address,
+                path_id,
+                is_active,
+            ),
             _ => {
                 trace!("ConnectionInner({:p}) Other callback", self);
                 Ok(())
@@ -1396,6 +1551,35 @@ pub enum ConnectionEvent {
     },
     /// A remote address has been removed.
     NotifyRemoteAddressRemoved { sequence_number: u64 },
+    /// A path has been added to the connection.
+    ///
+    /// Indicated when a path completes validation while multipath is
+    /// negotiated; the path is active at that point.
+    PathAdded {
+        local_address: SocketAddr,
+        peer_address: SocketAddr,
+        path_id: u32,
+    },
+    /// A path has been removed from the connection.
+    ///
+    /// Indicated when the peer abandons the path, and when a path validation
+    /// times out.
+    PathRemoved {
+        local_address: SocketAddr,
+        peer_address: SocketAddr,
+        path_id: u32,
+    },
+    /// The peer has declared a path available or backup.
+    ///
+    /// This reports the peer's view: it follows a PATH_AVAILABLE or PATH_BACKUP
+    /// frame arriving. Setting the status locally with
+    /// [`Connection::set_path_status()`] does not raise it.
+    PathStatusChanged {
+        local_address: SocketAddr,
+        peer_address: SocketAddr,
+        path_id: u32,
+        is_active: bool,
+    },
 }
 
 /// Errors that can occur when managing a connection.

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -1573,7 +1573,9 @@ pub enum ConnectionEvent {
     ///
     /// This reports the peer's view: it follows a PATH_AVAILABLE or PATH_BACKUP
     /// frame arriving. Setting the status locally with
-    /// [`Connection::set_path_status()`] does not raise it.
+    /// `Connection::set_path_status()` does not raise it. That method is not linked
+    /// here because it only exists on the `msquic-seera` backend, while this variant,
+    /// like the other backend-specific ones, is always present.
     PathStatusChanged {
         local_address: SocketAddr,
         peer_address: SocketAddr,

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -2079,6 +2079,101 @@ async fn test_poll_event_waker_notification() {
     });
 }
 
+/// Test for the multipath path events and ['Connection::set_path_status()'].
+///
+/// Drives the whole round trip: the client adds a second path, both ends see it
+/// validated as [`ConnectionEvent::PathAdded`], the client then declares it backup,
+/// and the server observes that as [`ConnectionEvent::PathStatusChanged`] — which is
+/// the only way the status can be read back, the parameter being set-only.
+#[cfg(feature = "msquic-seera")]
+#[test(tokio::test)]
+async fn test_path_events_and_set_path_status() {
+    use crate::ConnectionEvent;
+
+    /// Poll events until one matches, so an unrelated event in between does not
+    /// decide the test.
+    async fn next_event_matching(
+        conn: &Connection,
+        pred: impl Fn(&ConnectionEvent) -> bool,
+    ) -> ConnectionEvent {
+        timeout(Duration::from_secs(10), async {
+            loop {
+                let event = poll_fn(|cx| conn.poll_event(cx)).await.expect("poll_event");
+                if pred(&event) {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("expected event did not arrive")
+    }
+
+    let multipath = || {
+        msquic::Settings::new()
+            .set_IdleTimeoutMs(10000)
+            .set_MultipathEnabled()
+    };
+
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(&registration, &multipath()).unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+
+    let client_config = new_client_config(&registration, &multipath()).unwrap();
+    let conn = Connection::new(&registration).unwrap();
+
+    // Multipath identifies a connection by its source connection ID, which only a
+    // shared binding gives a non-zero length; without this the handshake is refused.
+    conn.set_share_binding(true).expect("set_share_binding");
+
+    let host = format!("{}", server_addr.ip());
+    let (started, accepted) = timeout(Duration::from_secs(10), async {
+        tokio::join!(
+            conn.start(&client_config, &host, server_addr.port()),
+            listener.accept(),
+        )
+    })
+    .await
+    .expect("connection was not established before the timeout");
+    started.expect("connection start");
+    let server_conn = accepted.expect("accept");
+
+    // A second path from another local port to the same server.
+    let local_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    conn.add_path(local_addr, server_addr).expect("add_path");
+
+    let (client_added, server_added) = tokio::join!(
+        next_event_matching(&conn, |e| matches!(e, ConnectionEvent::PathAdded { .. })),
+        next_event_matching(&server_conn, |e| matches!(
+            e,
+            ConnectionEvent::PathAdded { .. }
+        )),
+    );
+    let ConnectionEvent::PathAdded { path_id, .. } = client_added else {
+        unreachable!("filtered above");
+    };
+    assert!(
+        matches!(server_added, ConnectionEvent::PathAdded { .. }),
+        "the server sees the path too"
+    );
+
+    // Declaring the path backup sends PATH_BACKUP, which the server reports.
+    conn.set_path_status(path_id, false)
+        .expect("set_path_status");
+
+    let changed = next_event_matching(&server_conn, |e| {
+        matches!(e, ConnectionEvent::PathStatusChanged { .. })
+    })
+    .await;
+    let ConnectionEvent::PathStatusChanged { is_active, .. } = changed else {
+        unreachable!("filtered above");
+    };
+    assert!(!is_active, "the path was declared backup");
+}
+
 /// Test for ['Connection::poll_event()'] - returns ConnectionLost on shutdown completion
 #[cfg(feature = "msquic-seera")]
 #[test(tokio::test)]


### PR DESCRIPTION
## Summary

msquic indicates three events once multipath is negotiated — `QUIC_CONNECTION_EVENT_PATH_ADDED`, `_PATH_REMOVED` and `_PATH_STATUS_CHANGED` — which the seera bindings already expose but this crate dropped on the floor, along with `QUIC_PARAM_CONN_PATH_STATUS` for declaring a path available or backup to the peer.

Adds `ConnectionEvent::PathAdded`, `PathRemoved` and `PathStatusChanged`, dispatched like the other seera-only events, and `Connection::set_path_status()`. The three handlers share `handle_event_path`, since the events carry the same addresses and differ only in what they say about the path.

## What the events mean

Read out of the core at the pinned submodule commit:

| Event | Indicated when |
| --- | --- |
| `PathAdded` | a PATH_RESPONSE validates a path while multipath is negotiated (`connection.c:5095`), which is also where `QuicPathSetActive` makes it active. Its `path_id` is what `set_path_status()` takes. |
| `PathRemoved` | the peer abandons the path (`connection.c:5164`), and a path validation times out (`loss_detection.c:660`). |
| `PathStatusChanged` | a PATH_BACKUP (`connection.c:5255`) or PATH_AVAILABLE (`connection.c:5327`) frame arrives and flips `Path->IsActive`. It reports the **peer's** view; setting the status locally does not raise it. |

## No `get_path_status()`

`QUIC_PARAM_CONN_PATH_STATUS` is **set-only**. Its case appears solely in `QuicConnParamSet` (`connection.c:8934`); `QuicConnParamGet` has none and falls through to `default: QUIC_STATUS_INVALID_PARAMETER`, and no other parameter reports per-path status.

A getter would therefore have to be a cache this crate maintains rather than a read of the core's state, so none is added. The rustdoc on `set_path_status()` says as much and points at `PathStatusChanged`, which is what reports the peer's side. Reading it back for real needs a GET case added to the core first — happy to prepare that as a separate submodule change if it is wanted.

Setting the status writes `Path->IsActive` and, when that changes, raises PATH_AVAILABLE or PATH_BACKUP for the peer. Multipath has to be negotiated (`QUIC_STATUS_INVALID_STATE` otherwise) and the path id has to be known (`QUIC_STATUS_INVALID_PARAMETER` otherwise). Both are documented.

## Test

`test_path_events_and_set_path_status` negotiates multipath on both ends, adds a second path, waits for `PathAdded` on client *and* server, declares the path backup, and waits for the server's `PathStatusChanged` with `is_active: false`. Removing the `set_path_status()` call makes it fail on the timeout in 10s, so the assertion is doing work.

Two things the test had to get right, both found by running it:

- The client needs `Connection::set_share_binding(true)`, as `PathTest.cpp`'s `QuicTestMultipath` does. Multipath identifies a connection by its source connection ID, which only a shared binding gives a non-zero length; without it the handshake fails immediately with `QUIC_STATUS_PROTOCOL_ERROR`.
- The `join!` of start and accept is wrapped in a timeout — otherwise a failed handshake leaves `accept()` waiting for a peer that will never arrive, and the test hangs instead of failing.

## Test plan

- `cargo test -p msquic-async --lib --no-default-features --features tokio,msquic-seera` — 43 passed
- `cargo test -p msquic-async --lib` — 39 passed
- `cargo check -p msquic-async --all-targets` for `msquic-latest`, `msquic-2-5` and `msquic-seera` — clean
- `cargo clippy --workspace --all-targets --locked`, and again for the seera backend — clean
- `cargo rustdoc -p msquic-async -- -D rustdoc::broken_intra_doc_links` — clean, on default features and on the seera backend. This is the Build docs job, and it caught one thing worth noting: `ConnectionEvent`'s variants are not feature-gated, so a doc comment on one cannot link to a method that is. `PathStatusChanged` names `Connection::set_path_status()` in code formatting rather than linking to it, for that reason.
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

