### PR TITLE
feat(connection): let the application validate the peer's certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -97,6 +97,51 @@ checksum = "e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bindgen"
@@ -115,7 +160,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -218,10 +263,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "dtor"
@@ -353,7 +429,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -610,10 +686,11 @@ dependencies = [
  "seera-msquic",
  "tempfile",
  "test-log",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "x509-parser",
 ]
 
 [[package]]
@@ -636,10 +713,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -695,7 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -773,6 +887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +963,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -918,6 +1041,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +1094,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -958,7 +1103,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn",
+ "syn 2.0.118",
  "test-log-core",
 ]
 
@@ -968,7 +1113,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -979,7 +1133,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1046,7 +1211,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1081,7 +1246,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1243,3 +1408,20 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ tokio = "1.42.0"
 tokio-util = "0.7.9"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", default-features = false }
+x509-parser = "0.18"

--- a/msquic-async/Cargo.toml
+++ b/msquic-async/Cargo.toml
@@ -54,3 +54,4 @@ tempfile = { workspace = true }
 test-log = { workspace = true, features = ["trace"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "macros", "sync"] }
 tracing-subscriber = { workspace = true, features = ["fmt", "ansi", "env-filter", "time", "tracing-log"] }
+x509-parser = { workspace = true }

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -436,6 +436,51 @@ impl Connection {
             .map_err(ConnectionError::OtherError)
     }
 
+    /// Validate the peer's certificate yourself.
+    ///
+    /// The handler runs during the handshake, from the MsQuic thread, before the
+    /// connection is established — so it has to be set before [`Connection::start()`].
+    /// Returning `Ok(())` accepts the certificate; returning `Err(status)` rejects it,
+    /// and the handshake fails with that status. Without a handler every certificate
+    /// that reaches this event is accepted.
+    ///
+    /// MsQuic only raises the event when the configuration's credentials carry
+    /// `CredentialFlags::INDICATE_CERTIFICATE_RECEIVED`. Pair it with
+    /// `NO_CERTIFICATE_VALIDATION` to replace MsQuic's own checks, or with
+    /// `DEFER_CERTIFICATE_VALIDATION` to let them run first and report their verdict
+    /// through the two `deferred_*` arguments.
+    ///
+    /// The four arguments are the event's fields, passed through as MsQuic gives them:
+    ///
+    /// - `certificate`, the peer's certificate. Its type is platform specific: a
+    ///   `QUIC_BUFFER*` holding the DER encoding when the credentials carry
+    ///   `USE_PORTABLE_CERTIFICATES`, and otherwise the platform's own handle — an
+    ///   OpenSSL `X509*`, a Schannel `PCCERT_CONTEXT`. Passing that flag is what makes
+    ///   the certificate parseable without platform-specific code.
+    /// - `deferred_error_flags`, a bitmask of the errors MsQuic's own validation found.
+    ///   Only meaningful with `DEFER_CERTIFICATE_VALIDATION`, and only on Schannel;
+    ///   zero everywhere else.
+    /// - `deferred_status`, the most severe of those errors, under the same condition.
+    /// - `chain`, the certificate chain, platform specific in the same way.
+    ///
+    /// Both pointers are owned by MsQuic and valid only for the duration of the call,
+    /// so anything needed afterwards has to be copied out. The handler is called with
+    /// this connection's lock held, so it must not call back into the same
+    /// `Connection`.
+    ///
+    /// Asynchronous validation — returning `QUIC_STATUS_PENDING` and answering later
+    /// through `certificate_validation_complete()` — is not wired up here; the handler
+    /// has to reach its verdict before it returns.
+    pub fn set_peer_certificate_received_callback<F>(&self, handler: F)
+    where
+        F: FnMut(*mut c_void, u32, msquic::Status, *mut c_void) -> Result<(), msquic::Status>
+            + 'static
+            + Send,
+    {
+        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
+        exclusive.peer_certificate_received_callback = Some(Box::new(handler));
+    }
+
     /// Set whether to share the UDP binding.
     pub fn set_share_binding(&self, share: bool) -> Result<(), ConnectionError> {
         let share: u8 = if share { 1 } else { 0 };
@@ -783,6 +828,13 @@ impl Drop for ConnectionInstance {
     }
 }
 
+/// Handler installed by [`Connection::set_peer_certificate_received_callback()`],
+/// which documents the arguments. Boxed because it is stored per connection, and
+/// `Send` because it runs on a MsQuic thread rather than the one that set it.
+type PeerCertificateReceivedCallback = dyn FnMut(*mut c_void, u32, msquic::Status, *mut c_void) -> Result<(), msquic::Status>
+    + 'static
+    + Send;
+
 struct ConnectionInner {
     exclusive: Mutex<ConnectionInnerExclusive>,
     /// Kept here, rather than only on `ConnectionInstance`, so the callback
@@ -808,6 +860,7 @@ struct ConnectionInnerExclusive {
     event_waiters: Vec<Waker>,
     sslkeylog_file: Option<File>,
     tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
+    peer_certificate_received_callback: Option<Box<PeerCertificateReceivedCallback>>,
 }
 
 impl ConnectionInnerExclusive {
@@ -874,7 +927,37 @@ impl ConnectionInner {
                 event_waiters: Vec::new(),
                 sslkeylog_file,
                 tls_secrets,
+                peer_certificate_received_callback: None,
             }),
+        }
+    }
+
+    /// Hand the peer's certificate to the application's handler, if it set one.
+    ///
+    /// The status returned here is the event's status, which MsQuic reads as the
+    /// verdict: anything failing rejects the certificate and fails the handshake. With
+    /// no handler installed the event succeeds, leaving whatever validation the
+    /// credentials asked for as the only check.
+    ///
+    /// The lock is held across the call. That is what makes the `&mut` borrow of the
+    /// handler sound — MsQuic can raise this on any of its threads — and it is why the
+    /// handler must not call back into this `Connection`.
+    fn handle_event_peer_certificate_received(
+        &self,
+        certificate: *mut c_void,
+        deferred_error_flags: u32,
+        deferred_status: msquic::Status,
+        chain: *mut c_void,
+    ) -> Result<(), msquic::Status> {
+        trace!("ConnectionInner({:p}) PeerCertificateReceived", self);
+        if let Some(callback) = &mut self
+            .exclusive
+            .lock_poison_tolerant()
+            .peer_certificate_received_callback
+        {
+            callback(certificate, deferred_error_flags, deferred_status, chain)
+        } else {
+            Ok(())
         }
     }
 
@@ -1429,6 +1512,17 @@ impl ConnectionInner {
         ev: msquic::ConnectionEvent,
     ) -> Result<(), msquic::Status> {
         match ev {
+            msquic::ConnectionEvent::PeerCertificateReceived {
+                certificate,
+                deferred_error_flags,
+                deferred_status,
+                chain,
+            } => self.handle_event_peer_certificate_received(
+                certificate,
+                deferred_error_flags,
+                deferred_status,
+                chain,
+            ),
             msquic::ConnectionEvent::Connected {
                 session_resumed,
                 negotiated_alpn,

--- a/msquic-async/src/connection.rs
+++ b/msquic-async/src/connection.rs
@@ -440,45 +440,87 @@ impl Connection {
     ///
     /// The handler runs during the handshake, from the MsQuic thread, before the
     /// connection is established — so it has to be set before [`Connection::start()`].
-    /// Returning `Ok(())` accepts the certificate; returning `Err(status)` rejects it,
-    /// and the handshake fails with that status. Without a handler every certificate
-    /// that reaches this event is accepted.
+    /// Without a handler every certificate that reaches this event is accepted.
     ///
     /// MsQuic only raises the event when the configuration's credentials carry
     /// `CredentialFlags::INDICATE_CERTIFICATE_RECEIVED`. Pair it with
     /// `NO_CERTIFICATE_VALIDATION` to replace MsQuic's own checks, or with
     /// `DEFER_CERTIFICATE_VALIDATION` to let them run first and report their verdict
-    /// through the two `deferred_*` arguments.
+    /// through the `deferred_*` arguments.
+    ///
+    /// # Verdict
+    ///
+    /// `Ok(())` accepts. `Err(status)` rejects **only if `status` is one MsQuic
+    /// classifies as a failure** — the status is passed through untouched, so
+    /// `Err(Status(QUIC_STATUS_SUCCESS))` accepts just as `Ok(())` does, and
+    /// `Err(Status(QUIC_STATUS_PENDING))` leaves validation outstanding until the
+    /// connection times out, because the completion call that would answer it is not
+    /// exposed. Reject with something like `QUIC_STATUS_BAD_CERTIFICATE`.
+    ///
+    /// Asynchronous validation — returning `QUIC_STATUS_PENDING` and answering later
+    /// through MsQuic's `certificate_validation_complete()` — is not wired up here; the
+    /// handler has to reach its verdict before it returns.
+    ///
+    /// # Arguments
     ///
     /// The four arguments are the event's fields, passed through as MsQuic gives them:
     ///
-    /// - `certificate`, the peer's certificate. Its type is platform specific: a
-    ///   `QUIC_BUFFER*` holding the DER encoding when the credentials carry
-    ///   `USE_PORTABLE_CERTIFICATES`, and otherwise the platform's own handle — an
-    ///   OpenSSL `X509*`, a Schannel `PCCERT_CONTEXT`. Passing that flag is what makes
-    ///   the certificate parseable without platform-specific code.
+    /// - `certificate`, the peer's certificate, **which may be null**. Its type is
+    ///   platform specific: a `QUIC_BUFFER*` holding the DER encoding when the
+    ///   credentials carry `USE_PORTABLE_CERTIFICATES`, and otherwise the platform's own
+    ///   handle — an OpenSSL `X509*`, a Schannel `PCCERT_CONTEXT`. Passing that flag is
+    ///   what makes the certificate parseable without platform-specific code.
     /// - `deferred_error_flags`, a bitmask of the errors MsQuic's own validation found.
-    ///   Only meaningful with `DEFER_CERTIFICATE_VALIDATION`, and only on Schannel;
-    ///   zero everywhere else.
-    /// - `deferred_status`, the most severe of those errors, under the same condition.
-    /// - `chain`, the certificate chain, platform specific in the same way.
+    ///   Schannel only; zero on every other platform, whatever the credential flags.
+    /// - `deferred_status`, the most severe of those errors. Unlike the flags this is
+    ///   filled on OpenSSL too, whenever `DEFER_CERTIFICATE_VALIDATION` or
+    ///   `REQUIRE_CLIENT_AUTHENTICATION` is set, and is then the only field carrying
+    ///   MsQuic's verdict.
+    /// - `chain`, the certificate chain, **which may also be null** — including when
+    ///   `certificate` is not. It is not the same shape as `certificate`: with
+    ///   `USE_PORTABLE_CERTIFICATES` it is a `QUIC_BUFFER*` holding a **PKCS#7** blob
+    ///   rather than a bare certificate, and without the flag an OpenSSL
+    ///   `X509_STORE_CTX*` or a Schannel `HCERTSTORE`.
     ///
-    /// Both pointers are owned by MsQuic and valid only for the duration of the call,
-    /// so anything needed afterwards has to be copied out. The handler is called with
-    /// this connection's lock held, so it must not call back into the same
-    /// `Connection`.
+    /// A peer that sent no certificate reaches the handler with nulls rather than being
+    /// rejected first, since the check that would have rejected it is the validation
+    /// `NO_CERTIFICATE_VALIDATION` turns off. Check before dereferencing.
     ///
-    /// Asynchronous validation — returning `QUIC_STATUS_PENDING` and answering later
-    /// through `certificate_validation_complete()` — is not wired up here; the handler
-    /// has to reach its verdict before it returns.
+    /// Both pointers are owned by MsQuic and valid only for the duration of the call, so
+    /// anything needed afterwards has to be copied out.
+    ///
+    /// # What the handler must not do
+    ///
+    /// It must not capture this [`Connection`], or any clone of it. The handler is
+    /// stored inside the connection, so capturing one makes a reference cycle: the
+    /// connection is never dropped, `ConnectionClose` is never called, and the
+    /// registration's rundown never completes — failing at shutdown, far from the cause.
+    /// Capture what it needs (a channel, a root store) instead.
+    ///
+    /// It must not call [`Connection::set_peer_certificate_received_callback()`] on this
+    /// same connection, which would deadlock on the handler's own lock. Other methods
+    /// are fine: the handler is kept under a lock of its own, not the one the rest of
+    /// the connection uses. It should still return promptly — it runs on a MsQuic worker
+    /// thread, and blocking there on network I/O (OCSP, CRL) stalls that worker.
+    ///
+    /// # Server side
+    ///
+    /// Effectively client-only today. On a connection from [`crate::Listener::accept()`]
+    /// the handshake is already under way by the time the application receives it, so
+    /// with `REQUIRE_CLIENT_AUTHENTICATION` the event can be raised before a handler
+    /// can be installed — and an event with no handler accepts. Handing the handler in
+    /// through the listener, so it is in place before the connection is indicated, is
+    /// left to a later change.
     pub fn set_peer_certificate_received_callback<F>(&self, handler: F)
     where
         F: FnMut(*mut c_void, u32, msquic::Status, *mut c_void) -> Result<(), msquic::Status>
             + 'static
             + Send,
     {
-        let mut exclusive = self.0.exclusive.lock_poison_tolerant();
-        exclusive.peer_certificate_received_callback = Some(Box::new(handler));
+        *self
+            .0
+            .peer_certificate_received_callback
+            .lock_poison_tolerant() = Some(Box::new(handler));
     }
 
     /// Set whether to share the UDP binding.
@@ -840,6 +882,11 @@ struct ConnectionInner {
     /// Kept here, rather than only on `ConnectionInstance`, so the callback
     /// context can reserve for peer-initiated streams.
     rundown: Arc<RundownState>,
+    /// Deliberately its own lock rather than a field of `exclusive`. The handler
+    /// is arbitrary application code called while this is held, so putting it in
+    /// `exclusive` would mean every `Connection` method it touched deadlocked the
+    /// MsQuic thread inside the TLS callback.
+    peer_certificate_received_callback: Mutex<Option<Box<PeerCertificateReceivedCallback>>>,
 }
 
 struct ConnectionInnerExclusive {
@@ -860,7 +907,6 @@ struct ConnectionInnerExclusive {
     event_waiters: Vec<Waker>,
     sslkeylog_file: Option<File>,
     tls_secrets: Option<Box<msquic::ffi::QUIC_TLS_SECRETS>>,
-    peer_certificate_received_callback: Option<Box<PeerCertificateReceivedCallback>>,
 }
 
 impl ConnectionInnerExclusive {
@@ -909,6 +955,7 @@ impl ConnectionInner {
     ) -> Self {
         Self {
             rundown,
+            peer_certificate_received_callback: Mutex::new(None),
             exclusive: Mutex::new(ConnectionInnerExclusive {
                 state,
                 error: None,
@@ -927,7 +974,6 @@ impl ConnectionInner {
                 event_waiters: Vec::new(),
                 sslkeylog_file,
                 tls_secrets,
-                peer_certificate_received_callback: None,
             }),
         }
     }
@@ -939,9 +985,10 @@ impl ConnectionInner {
     /// no handler installed the event succeeds, leaving whatever validation the
     /// credentials asked for as the only check.
     ///
-    /// The lock is held across the call. That is what makes the `&mut` borrow of the
-    /// handler sound — MsQuic can raise this on any of its threads — and it is why the
-    /// handler must not call back into this `Connection`.
+    /// The handler's own lock is held across the call, which is what makes the `&mut`
+    /// borrow sound — MsQuic can raise this on any of its threads. That lock guards
+    /// nothing else, so a handler is free to use the rest of this `Connection`; only
+    /// installing another handler from inside one would deadlock.
     fn handle_event_peer_certificate_received(
         &self,
         certificate: *mut c_void,
@@ -950,10 +997,9 @@ impl ConnectionInner {
         chain: *mut c_void,
     ) -> Result<(), msquic::Status> {
         trace!("ConnectionInner({:p}) PeerCertificateReceived", self);
-        if let Some(callback) = &mut self
-            .exclusive
-            .lock_poison_tolerant()
+        if let Some(callback) = &mut *self
             .peer_certificate_received_callback
+            .lock_poison_tolerant()
         {
             callback(certificate, deferred_error_flags, deferred_status, chain)
         } else {

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -100,6 +100,177 @@ async fn test_connection_start() {
     });
 }
 
+/// Test for ['Connection::set_peer_certificate_received_callback()'] - accepting.
+///
+/// The client turns MsQuic's own validation off, so the handler is the only thing
+/// standing between the handshake and completion. It parses the certificate the
+/// server presented and checks its common name, which is what a real caller
+/// replacing the built-in validation would do.
+#[test(tokio::test)]
+async fn test_connection_custom_cert_validation_success() {
+    let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        server_rx.recv().await.unwrap();
+
+        server_tx.send(()).await.unwrap();
+        drop(listener);
+    });
+
+    let client_config = new_client_config_with_custom_cert_validation(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    let expected_cn = "localhost".to_string();
+    conn.set_peer_certificate_received_callback(
+        move |certificate, _deferred_error_flags, _deferred_status, _chain| {
+            // USE_PORTABLE_CERTIFICATES is set on the configuration, so `certificate`
+            // is a `QUIC_BUFFER*` holding the DER encoding. It belongs to MsQuic and
+            // lives only for this call, which is fine — the parse and the check both
+            // happen here.
+            let cert = unsafe {
+                use x509_parser::prelude::*;
+                let (_, cert) = X509Certificate::from_der(
+                    msquic::BufferRef::from_ffi_ref(
+                        (certificate as *const msquic::ffi::QUIC_BUFFER)
+                            .as_ref()
+                            .unwrap(),
+                    )
+                    .as_bytes(),
+                )
+                .unwrap();
+                cert
+            };
+            let cn = cert
+                .subject()
+                .iter_common_name()
+                .next()
+                .and_then(|cn| cn.as_str().ok())
+                .unwrap();
+            assert_eq!(cn, expected_cn);
+            // Accepting here is what lets the handshake complete, which is what the
+            // client task below asserts.
+            Ok(())
+        },
+    );
+
+    set.spawn(async move {
+        let res = conn
+            .start(
+                &client_config,
+                &format!("{}", server_addr.ip()),
+                server_addr.port(),
+            )
+            .await;
+        assert!(res.is_ok());
+        client_tx.send(()).await.unwrap();
+
+        client_rx.recv().await.unwrap();
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
+/// Test for ['Connection::set_peer_certificate_received_callback()'] - rejecting.
+///
+/// The mirror of the test above: the handler refuses every certificate, and the
+/// client's `start()` has to fail as a result. Since MsQuic's own validation is off,
+/// a handler whose verdict was ignored would let this connection through, so the
+/// assertion is on the handler being what decides.
+#[test(tokio::test)]
+async fn test_connection_custom_cert_validation_fail() {
+    let (client_tx, mut server_rx) = mpsc::channel::<()>(1);
+    let (server_tx, mut client_rx) = mpsc::channel::<()>(1);
+
+    let registration = crate::Registration::new(&msquic::RegistrationConfig::default()).unwrap();
+    let listener = new_server(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    listener
+        .start(&[msquic::BufferRef::from("test")], Some(addr))
+        .expect("listener start");
+    let server_addr = listener.local_addr().expect("listener local_addr");
+    let mut set = JoinSet::new();
+
+    set.spawn(async move {
+        let _conn = listener.accept().await.unwrap();
+        server_rx.recv().await.unwrap();
+
+        server_tx.send(()).await.unwrap();
+        drop(listener);
+    });
+
+    let client_config = new_client_config_with_custom_cert_validation(
+        &registration,
+        &msquic::Settings::new().set_IdleTimeoutMs(10000),
+    )
+    .unwrap();
+    let conn = Connection::new(&registration).unwrap();
+    conn.set_peer_certificate_received_callback(
+        |_certificate, _deferred_error_flags, _deferred_status, _chain| {
+            Err(msquic::Status::from(
+                msquic::ffi::QUIC_STATUS_BAD_CERTIFICATE,
+            ))
+        },
+    );
+
+    set.spawn(async move {
+        let res = conn
+            .start(
+                &client_config,
+                &format!("{}", server_addr.ip()),
+                server_addr.port(),
+            )
+            .await;
+        assert!(res.is_err());
+        client_tx.send(()).await.unwrap();
+
+        client_rx.recv().await.unwrap();
+    });
+
+    let mut results = Vec::new();
+    while let Some(res) = set.join_next().await {
+        results.push(res);
+    }
+    results.into_iter().for_each(|res| {
+        if let Err(err) = res {
+            if err.is_panic() {
+                std::panic::resume_unwind(err.into_panic());
+            }
+        }
+    });
+}
+
 /// Test for ['Connection::shutdown()']
 #[test(tokio::test)]
 async fn test_connection_poll_shutdown() {
@@ -2593,6 +2764,30 @@ fn new_client_config(
         .unwrap();
     let cred_config = msquic::CredentialConfig::new_client()
         .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
+    configuration.load_credential(&cred_config).unwrap();
+    Ok(configuration)
+}
+
+/// A client configuration that hands certificate validation to the application.
+///
+/// The three flags are additive — `set_credential_flags` ORs each call into the set —
+/// and each does one job: `NO_CERTIFICATE_VALIDATION` stops MsQuic checking the
+/// certificate itself, `INDICATE_CERTIFICATE_RECEIVED` is what makes it raise the
+/// event at all, and `USE_PORTABLE_CERTIFICATES` makes the certificate arrive as a
+/// `QUIC_BUFFER` of DER rather than an OpenSSL or Schannel handle, which is what lets
+/// the tests below parse it with x509-parser on any platform.
+fn new_client_config_with_custom_cert_validation(
+    registration: &crate::Registration,
+    settings: &msquic::Settings,
+) -> Result<msquic::Configuration> {
+    let alpn = [msquic::BufferRef::from("test")];
+    let configuration = registration
+        .open_configuration(&alpn, Some(settings))
+        .unwrap();
+    let cred_config = msquic::CredentialConfig::new_client()
+        .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION)
+        .set_credential_flags(msquic::CredentialFlags::INDICATE_CERTIFICATE_RECEIVED)
+        .set_credential_flags(msquic::CredentialFlags::USE_PORTABLE_CERTIFICATES);
     configuration.load_credential(&cred_config).unwrap();
     Ok(configuration)
 }

--- a/msquic-async/src/tests.rs
+++ b/msquic-async/src/tests.rs
@@ -138,36 +138,50 @@ async fn test_connection_custom_cert_validation_success() {
     )
     .unwrap();
     let conn = Connection::new(&registration).unwrap();
-    let expected_cn = "localhost".to_string();
+
+    // The handler reports what it saw instead of asserting in place. A panic inside it
+    // would be swallowed by the `catch_unwind` in the connection callback and surface
+    // only as a failed `start()`, and a handler that never ran would leave the test
+    // asserting nothing at all. Both show up as a missing or unexpected message here.
+    let (cert_tx, mut cert_rx) = mpsc::channel::<Result<String, String>>(1);
     conn.set_peer_certificate_received_callback(
         move |certificate, _deferred_error_flags, _deferred_status, _chain| {
             // USE_PORTABLE_CERTIFICATES is set on the configuration, so `certificate`
             // is a `QUIC_BUFFER*` holding the DER encoding. It belongs to MsQuic and
-            // lives only for this call, which is fine — the parse and the check both
-            // happen here.
-            let cert = unsafe {
+            // lives only for this call, so the common name is copied out.
+            let common_name = (|| {
+                let der = unsafe {
+                    let buffer = (certificate as *const msquic::ffi::QUIC_BUFFER)
+                        .as_ref()
+                        .ok_or("no certificate was presented")?;
+                    msquic::BufferRef::from_ffi_ref(buffer).as_bytes()
+                };
                 use x509_parser::prelude::*;
-                let (_, cert) = X509Certificate::from_der(
-                    msquic::BufferRef::from_ffi_ref(
-                        (certificate as *const msquic::ffi::QUIC_BUFFER)
-                            .as_ref()
-                            .unwrap(),
-                    )
-                    .as_bytes(),
-                )
-                .unwrap();
-                cert
-            };
-            let cn = cert
-                .subject()
-                .iter_common_name()
-                .next()
-                .and_then(|cn| cn.as_str().ok())
-                .unwrap();
-            assert_eq!(cn, expected_cn);
-            // Accepting here is what lets the handshake complete, which is what the
-            // client task below asserts.
-            Ok(())
+                let (_, cert) =
+                    X509Certificate::from_der(der).map_err(|err| format!("bad DER: {err}"))?;
+                let common_name = cert
+                    .subject()
+                    .iter_common_name()
+                    .next()
+                    .and_then(|cn| cn.as_str().ok())
+                    .map(|cn| cn.to_string())
+                    .ok_or_else(|| "no common name".to_string());
+                common_name
+            })();
+
+            let accepted = common_name.is_ok();
+            cert_tx
+                .try_send(common_name)
+                .expect("test receiver is waiting");
+            if accepted {
+                // Accepting is what lets the handshake complete, which the client task
+                // below asserts.
+                Ok(())
+            } else {
+                Err(msquic::Status::from(
+                    msquic::ffi::QUIC_STATUS_BAD_CERTIFICATE,
+                ))
+            }
         },
     );
 
@@ -185,6 +199,11 @@ async fn test_connection_custom_cert_validation_success() {
         client_rx.recv().await.unwrap();
     });
 
+    // Collected here, but asserted at the end. Panicking while the tasks below are
+    // still in flight leaves the connection half torn down and the test hanging on
+    // shutdown instead of reporting the failure.
+    let reported = timeout(Duration::from_secs(10), cert_rx.recv()).await;
+
     let mut results = Vec::new();
     while let Some(res) = set.join_next().await {
         results.push(res);
@@ -196,6 +215,12 @@ async fn test_connection_custom_cert_validation_success() {
             }
         }
     });
+
+    // The handler ran, and saw the certificate the server was configured with.
+    let common_name = reported
+        .expect("the certificate handler was never called")
+        .expect("the certificate handler dropped its sender");
+    assert_eq!(common_name.as_deref(), Ok("localhost"));
 }
 
 /// Test for ['Connection::set_peer_certificate_received_callback()'] - rejecting.


### PR DESCRIPTION
## Summary

MsQuic raises `QUIC_CONNECTION_EVENT_PEER_CERTIFICATE_RECEIVED` during the handshake when the credentials carry `INDICATE_CERTIFICATE_RECEIVED`, and reads the status the application returns as the verdict on that certificate. This crate dropped the event, so there was no way to validate a peer yourself.

`Connection::set_peer_certificate_received_callback()` installs a handler for it, with two client-side tests. The handler is kept under a lock of its own on `ConnectionInner` — not the connection's `exclusive` lock, which is what every other method takes — so a handler is free to use the rest of the connection while it decides.

## The verdict

`Ok(())` accepts. `Err(status)` rejects **only if `status` is one MsQuic classifies as a failure**: the status is passed through untouched, so `Err(Status(QUIC_STATUS_SUCCESS))` accepts exactly as `Ok(())` does, and `Err(Status(QUIC_STATUS_PENDING))` leaves validation outstanding until the connection times out, because the completion call that would answer it is not exposed. Reject with something like `QUIC_STATUS_BAD_CERTIFICATE`.

Rejecting does stop the handshake: `QuicConnIndicateEvent`'s failure status makes the core log `"Custom cert validation failed"` and return FALSE to the TLS layer (`connection.c:3208`).

## What the arguments really are

The four arguments are the event's fields passed straight through, and their contract is not visible in their types. All of this is checked against the vendored core at the pinned submodule commit and is now in the rustdoc:

- **`certificate` and `chain` can be null.** The `Cert == NULL` rejection at `tls_openssl.c:999` sits inside a block guarded by `!(NO_CERTIFICATE_VALIDATION)` — the flag a caller replacing the built-in validation sets — so a peer that sent no certificate reaches the handler with nulls rather than being refused first. Schannel has the same shape via `QUIC_CERT_BLOB_NONE`.
- **`certificate` is platform specific.** With `USE_PORTABLE_CERTIFICATES` it is a `QUIC_BUFFER*` of DER (`tls_openssl.c:1109` hands `&PortableCertificate` instead of the `X509*`); without it, the platform's own handle.
- **`chain` is not the same shape.** With portable certificates it is a **PKCS#7** blob (`i2d_PKCS7` at `tls_openssl.c:1093`, `CERT_STORE_SAVE_AS_PKCS7` at `cert_capi.c:836`), not a bare certificate; without the flag an `X509_STORE_CTX*` or an `HCERTSTORE`.
- **`deferred_status` is not Schannel-only.** `tls_openssl.c:1113` passes `ValidationResult`, filled whenever `DEFER_CERTIFICATE_VALIDATION` or `REQUIRE_CLIENT_AUTHENTICATION` is set, and it is then the only field carrying MsQuic's verdict. Only `deferred_error_flags` is Schannel-only, hard-coded to `0` on the line above.

Both pointers are owned by MsQuic and valid only for the duration of the call (`msquic.h:1445`).

## Two traps with no fix here, documented instead

- **The handler must not capture the `Connection`**, or a clone of it. It is stored inside the connection, so capturing one is a reference cycle: the connection is never dropped, `ConnectionClose` is never called, and the registration's rundown never completes — failing at shutdown, far from the cause.
- **The server side is effectively unusable today.** On a connection from `Listener::accept()` the handshake is already under way by the time the application receives it, so with `REQUIRE_CLIENT_AUTHENTICATION` the event can be raised before a handler can be installed — and an event with no handler accepts. Handing the handler in through the listener, so it is in place before the connection is indicated, is left to a later change.

Also unexposed, and documented as such: asynchronous validation via `QUIC_STATUS_PENDING` and `ConnectionCertificateValidationComplete` (`crypto.c:1735`).

## Tests

Two, both client side, on a configuration with `NO_CERTIFICATE_VALIDATION` so the handler is the only gate, plus `INDICATE_CERTIFICATE_RECEIVED` to raise the event and `USE_PORTABLE_CERTIFICATES` so the certificate arrives as DER and x509-parser can read it on any platform. The three `set_credential_flags` calls look like they overwrite each other; they are additive (`|=`, and the binding documents it), which the helper now says.

- `_success` reports the certificate's common name **out of the handler over a channel** and asserts on it in the test body. Assertions inside the handler are swallowed by `callback_handler_impl`'s `catch_unwind`, so a wrong name surfaced only as `start()` failing and a handler that never ran asserted nothing at all.
  The assert comes after the `JoinSet` is drained, because panicking while the tasks are in flight leaves the connection half torn down and the test hangs on shutdown instead of failing. Pointed at the wrong name it now fails in 0.09s with both values printed.
- `_fail` rejects everything with `QUIC_STATUS_BAD_CERTIFICATE`, and `start()` has to fail. With MsQuic's own validation off, a handler whose verdict was ignored would let that connection through, so the assertion is on the handler being what decides.

`x509-parser` is a dev-dependency only — nothing in the library parses certificates.

## Test plan

- `cargo test -p msquic-async --lib` — 41 passed
- `cargo test -p msquic-async --lib --no-default-features --features tokio,msquic-seera` — 45 passed
- `cargo check -p msquic-async --all-targets` for `msquic-latest`, `msquic-2-5` and `msquic-seera` — clean; the event exists on all three, so no feature gate is needed
- `cargo clippy --workspace --all-targets --locked` — clean
- `cargo fmt --check`, `cargo rustdoc -p msquic-async -- -D rustdoc::broken_intra_doc_links` — clean

The implementation is @masa-koz's; the documentation, the lock split and the test rework came from reviewing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
